### PR TITLE
FIX: OpenDSS switch parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
-- none
+- FIX: OpenDSS parsing of `switch=y` property on lines (#161)
 
 ### v0.5.2
 - Fix bug in OpenDSS parser on Capacitors (#158)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -186,7 +186,7 @@ function _create_line(bus1, bus2, name::AbstractString; kwargs...)
     xgmod = xg != 0.0 ?  0.5 * kxg * log(freq / basefreq) : 0.0
 
     units = get(kwargs, :units, "none")
-    len = get(kwargs, :length, 1.0) * _convert_to_meters[units]
+    len = get(kwargs, :switch, false) ? 0.001 : get(kwargs, :length, 1.0) * _convert_to_meters[units]
 
     if haskey(kwargs, :rg)
         Memento.warn(_LOGGER, "Rg,Xg are not fully supported")

--- a/test/data/opendss/case3_balanced_switch.dss
+++ b/test/data/opendss/case3_balanced_switch.dss
@@ -1,0 +1,37 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  switch=y ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -14,10 +14,10 @@ New Line.L1  bus1=b1 bus2=_b2 length=0.001 units=mi r1=0.001 r0=0.001 x1=0.01 x0
 New Line.L1-2 bus1=b3-1.2 bus2=b4.2 length=0.032175613 units=km Linecode=lc1
 New Line.L2 bus1=b5 bus2=b6_check-chars length=0.013516796 units=none linecode=lc/2
 New "Line.L3" phases=3 bus1=b7.1.2.3 bus2=b9.1.2.3 linecode=300 normamps=400 emergamps=600 faultrate=0.1 pctperm=20 repair=0 length=2.58
-New "Line._L4" phases=3 bus1=b8.1.2.3 bus2=b10.1.2.3 linecode=300 normamps=400 emergamps=600 faultrate=0.1 pctperm=20 repair=0 length=1.73
+New "Line._L4" phases=3 bus1=b8.1.2.3 bus2=b10.1.2.3 linecode=300 normamps=400 emergamps=600 faultrate=0.1 pctperm=20 repair=0 length=1.73 switch=y
 New line.l5 phases=3 bus1=_b2.1.2.3.0 bus2=b7.1.2.3.0 linecode=lc8
 New line.l6 phases=3 bus1=b1.1.2.3 bus2=b10.1.2.3 linecode=lc9
-new line.l7 bus1=_b2 bus2=b10 like=L2 linecode=lc10 switch=y
+new line.l7 bus1=_b2 bus2=b10 like=L2 linecode=lc10
 
 ! Loads
 New Load.ld1 phases=1 Bus1=b7.1.2  kv=0.208  status=variable model=1 conn=wye kW=3.89   pf=0.97  Vminpu=.88

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -218,8 +218,9 @@
         @test length(pmd2["bus"]) == 6 # updated nr of buses
 
         @testset "branches with switches" begin
-            @test pmd["branch"]["8"]["switch"]
-            @test all([pmd["branch"]["$i"]["switch"] == false for i in 1:6])
+            @test pmd["branch"]["5"]["switch"]
+            @test pmd["branch"]["5"]["length"] == 0.001
+            @test all([pmd["branch"]["$i"]["switch"] == false for i in 1:4])
         end
 
         @testset "whitespace before ~" begin

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -55,6 +55,21 @@
         @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00923328; atol=1e-4)
     end
 
+    @testset "3-bus balanced w/ switch" begin
+        pmd = PMD.parse_file("../test/data/opendss/case3_balanced_switch.dss")
+        sol = PMD.run_mc_pf(pmd, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["termination_status"] == PMs.LOCALLY_SOLVED
+
+        for (bus, va, vm) in zip(["1", "2", "3"], [0.0, 0.0, deg2rad(-0.04)], [0.9959, 0.995729, 0.985454])
+            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [PMD._wrap_to_pi(2*pi/pmd["conductors"]*(1-c) .+ va) for c in 1:pmd["conductors"]]; atol=deg2rad(0.2)))
+            @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=1e-3))
+        end
+
+        # @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018185; atol=1e-5)
+        # @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00910435; atol=1e-4)
+    end
+
     @testset "3-bus unbalanced" begin
         pmd = PMD.parse_file("../test/data/opendss/case3_unbalanced.dss")
         sol = PMD.run_mc_pf(pmd, PMs.ACPPowerModel, ipopt_solver)


### PR DESCRIPTION
In OpenDSS, the `switch=y` property results in `length=0.001` and `units=none`.

Fixing these values results in the correct voltages across the buses, but not the correct power, which I believe must be due to a different power balance constraint being applied than lines have in OpenDSS. This issue is already covered by #156

Changelog and unit tests updated.