### PR TITLE
FIX: OpenDSS transformer %rs and %loadloss handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
-- none
+- Fix bug in OpenDSS parser on Transformers (#162)
 
 ### v0.6.0
 - Update Formulation types to follow PowerModels v0.13 conventions (breaking) (#160)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -800,12 +800,19 @@ function _create_transformer(name::AbstractString; kwargs...)
     windings = get(kwargs, :windings, 2)
     phases = get(kwargs, :phases, 3)
 
+    prcnt_rs = fill(0.2, windings)
+    if haskey(kwargs, Symbol("%rs"))
+        prcnt_rs = kwargs[Symbol("%rs")]
+    elseif haskey(kwargs, Symbol("%loadloss"))
+        prcnt_rs[1] = prcnt_rs[2] = kwargs[Symbol("%loadloss")] / 2.0
+    end
+
     temp = Dict{String,Any}("buss" => get(kwargs, :buses, fill("", windings)),
                             "taps" => get(kwargs, :taps, fill(1.0, windings)),
                             "conns" => get(kwargs, :conns, fill("wye", windings)),
                             "kvs" => get(kwargs, :kvs, fill(12.47, windings)),
                             "kvas" => get(kwargs, :kvas, fill(10.0, windings)),
-                            "%rs" => fill(0.0, windings),
+                            "%rs" => prcnt_rs,
                             "rneuts" => fill(0.0, windings),
                             "xneuts" => fill(0.0, windings)
                            )
@@ -862,7 +869,7 @@ function _create_transformer(name::AbstractString; kwargs...)
                             "m" => get(kwargs, :m, 0.8),
                             "flrise" => get(kwargs, :flrise, 65.0),
                             "hsrise" => get(kwargs, :hsrise, 15.0),
-                            "%loadloss" => get(kwargs, Symbol("%loadloss"), 2.0 * temp["%rs"][1] * 100.0),  # CHECK:
+                            "%loadloss" => get(kwargs, Symbol("%loadloss"), sum(temp["%rs"][1:2])),
                             "%noloadloss" => get(kwargs, Symbol("%noloadloss"), 0.0),
                             "normhkva" => get(kwargs, :normhkva, 1.1 * temp["kvas"][1]),
                             "emerghkva" => get(kwargs, :emerghkva, 1.5 * temp["kvas"][1]),

--- a/test/data/opendss/ut_trans_3w_dyy_3_loadloss.dss
+++ b/test/data/opendss/ut_trans_3w_dyy_3_loadloss.dss
@@ -1,0 +1,38 @@
+clear
+
+! Base Frequency
+Set DefaultBaseFrequency=50
+
+! New Circuit
+New circuit.ut_trans
+~ BasekV=11 BaseMVA=0.1 pu=1.0  ISC3=9999999999 ISC1=9999999999
+
+! Transformers
+New Transformer.TX1 windings=3 phases=3 Buses=[1 2 3]
+~ Conns=[Delta Wye Wye]
+~ kVs=[11 4 0.4]
+~ kVAs=[500 500 500]
+~ %loadloss=0
+~ xhl=0 xht=0 xlt=0
+~ %noloadloss=0
+~ %imag=0
+~ leadlag=lead
+
+! Transmission Lines
+New Line.LINE1 Bus1=SourceBus Bus2=1 phases=3 X1=3 R1=6
+
+! Loads
+New Load.LOAD1 Phases=1 Bus1=2.1 kV=2.30 kW=43 kvar=76 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD2 Phases=1 Bus1=2.2 kV=2.30 kW=52 kvar=85 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD3 Phases=1 Bus1=2.3 kV=2.30 kW=61 kvar=94 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD4 Phases=1 Bus1=3.1 kV=0.23 kW=74 kvar=41 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD5 Phases=1 Bus1=3.2 kV=0.23 kW=85 kvar=52 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD6 Phases=1 Bus1=3.3 kV=0.23 kW=96 kvar=63 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD7 Phases=1 Bus1=1.3 kV=6.351 kW=205 kvar=185 vminpu=0.8 vmaxpu=1.2
+
+! Set Voltage Bases
+Set voltagebases=[11  4 0.4]
+Calcvoltagebases
+
+! Solve network
+solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -129,7 +129,7 @@
         # if rs=0, then 1 extra, else 3 extra
         # tr1:+1(rs=0), tr2:+3, tr3:+1(rs=0), tr4:+3, tr5:+1(rs=0)
         # 10 transformers, 2 per dss transformer
-        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "trans"], [26, 4, 5, 20, 4, 0, 10])
+        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "trans"], [32, 4, 5, 26, 4, 0, 10])
             @test haskey(pmd, key)
             @test length(pmd[key]) == len
         end
@@ -215,7 +215,7 @@
         end
 
         pmd2 = PMD.parse_file("../test/data/opendss/test_simple4.dss")
-        @test length(pmd2["bus"]) == 6 # updated nr of buses
+        @test length(pmd2["bus"]) == 9 # updated nr of buses
 
         @testset "branches with switches" begin
             @test pmd["branch"]["8"]["switch"]

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -68,6 +68,14 @@ vm(sol, pmd_data, name) = sol["solution"]["bus"][string(bus_name2id(pmd_data, na
             @test norm(vm(sol, pmd_data, "3")-[0.97047, 0.93949, 0.946], Inf) <= 1.5E-5
             @test norm(va(sol, pmd_data, "3")-[30.6, -90.0, 151.9], Inf) <= 0.5E-2
         end
+        @testset "%loadloss=0" begin
+            file = "../test/data/opendss/ut_trans_3w_dyy_3_loadloss.dss"
+            pmd_data = PMD.parse_file(file)
+            sol = PMD.run_ac_mc_pf(pmd_data, ipopt_solver, multiconductor=true)
+            @test haskey(sol["solution"]["bus"], "9")
+            @test norm(vm(sol, pmd_data, "3")-[0.969531, 0.938369, 0.944748], Inf) <= 1.5E-5
+            @test norm(va(sol, pmd_data, "3")-[30.7, -90.0, 152.0], Inf) <= 0.5E-2
+        end
     end
     @testset "voltage base" begin
         # make sure that different voltage bases lead to the same solution


### PR DESCRIPTION
Fixes the handling of `%rs` and `%loadloss` properties on OpenDSS transformers.

For 3-winding transformers:
`%loadloss = sum(%rs[1:2])`
`%rs = [%loadloss/2, %loadloss/2, 0.2]`

For 2-winding transformers, `%rs = fill(%loadloss / 2, 2)`

The default value `%r = 0.2` is corrected (was `0.0`)

Because the of the new default values, the number of star buses created for 3-winding transformers changes.

Changelog and Unit tests updated

Closes #157