### PR TITLE
FIX: Wrong setting of basefreq on lines / linecodes (OpenDSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
-- none
+- Fix bug in OpenDSS parser on Lines / Linecodes related to basefreq (#163)
 
 ### v0.6.0
 - Update Formulation types to follow PowerModels v0.13 conventions (breaking) (#160)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -26,7 +26,8 @@ This is now mainly used for parsing linecode dicts into correct data types.
 function _create_linecode(name::AbstractString; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :nphases, 3)
-    basefreq = get(kwargs, :basefreq, 60.0)
+    circuit_basefreq = get(kwargs, :circuit_basefreq, 60.0)
+    basefreq = get(kwargs, :basefreq, circuit_basefreq)
 
     r1 = get(kwargs, :r1, 0.058)
     x1 = get(kwargs, :x1, 0.1206)
@@ -120,7 +121,8 @@ properties.
 function _create_line(bus1, bus2, name::AbstractString; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :phases, 3)
-    basefreq = get(kwargs, :basefreq, 60.0)
+    circuit_basefreq = get(kwargs, :circuit_basefreq, 60.0)
+    basefreq = get(kwargs, :basefreq, circuit_basefreq)
 
     r1 = get(kwargs, :r1, 0.058)
     x1 = get(kwargs, :x1, 0.1206)
@@ -175,15 +177,13 @@ function _create_line(bus1, bus2, name::AbstractString; kwargs...)
     xg = get(kwargs, :xg, 0.155081)
     rho = get(kwargs, :rho, 100.0)
 
-    # TODO: calculate freq solution for circuit to use rg, xg
     # TODO: support length mismatch between line and linecode?
     # Currently this does not change the values of rmatrix and xmatrix due to
-    # freq=basefreq and lenmult=1, code is only in place for future use.
-    freq = basefreq
+    # lenmult=1, code is only in place for future use.
     lenmult = 1.0
 
-    kxg = xg / log(658.5 * sqrt(rho / basefreq))
-    xgmod = xg != 0.0 ?  0.5 * kxg * log(freq / basefreq) : 0.0
+    kxg = xg / log(658.5 * sqrt(rho / circuit_basefreq))
+    xgmod = xg != 0.0 ?  0.5 * kxg * log(basefreq / circuit_basefreq) : 0.0
 
     units = get(kwargs, :units, "none")
     len = get(kwargs, :length, 1.0) * _convert_to_meters[units]
@@ -192,10 +192,10 @@ function _create_line(bus1, bus2, name::AbstractString; kwargs...)
         Memento.warn(_LOGGER, "Rg,Xg are not fully supported")
     end
 
-    rmatrix .+= rg * (freq/basefreq - 1.0)
+    rmatrix .+= rg * (basefreq / circuit_basefreq - 1.0)
     rmatrix .*= lenmult
     xmatrix .-= xgmod
-    xmatrix .*= lenmult * (freq / basefreq)
+    xmatrix .*= lenmult * (basefreq / circuit_basefreq)
 
     return Dict{String,Any}("name" => name,
                             "bus1" => bus1,
@@ -233,8 +233,6 @@ function _create_line(bus1, bus2, name::AbstractString; kwargs...)
                             "repair" => get(kwargs, :repair, 3.0),
                             "basefreq" => basefreq,
                             "enabled" => get(kwargs, :enabled, true),
-                            # Added properties
-                            "freq" => freq
                            )
 end
 

--- a/test/data/opendss/case3_balanced_basefreq.dss
+++ b/test/data/opendss/case3_balanced_basefreq.dss
@@ -1,0 +1,37 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -53,6 +53,15 @@
 
         @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0183456; atol=1e-5)
         @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00923328; atol=1e-4)
+
+        @testset "3-bus balanced no linecode basefreq defined" begin
+            pmd2 = PMD.parse_file("../test/data/opendss/case3_balanced_basefreq.dss")
+            sol2 = PMD.run_mc_pf(pmd2, PMs.ACPPowerModel, ipopt_solver)
+
+            @test all(all(isapprox.(bus["vm"].values, sol2["solution"]["bus"][i]["vm"]; atol=1e-8)) for (i, bus) in sol["solution"]["bus"])
+            @test all(all(isapprox.(bus["va"].values, sol2["solution"]["bus"][i]["va"]; atol=1e-8)) for (i, bus) in sol["solution"]["bus"])
+            @test all(isapprox(sum(sol["solution"]["gen"]["1"][field] * sol["solution"]["baseMVA"]), sum(sol2["solution"]["gen"]["1"][field] * sol2["solution"]["baseMVA"]); atol=1e-8) for field in ["pg", "qg"])
+        end
     end
 
     @testset "3-bus unbalanced" begin


### PR DESCRIPTION
When lines / linecodes do not have the basefreq property, internally the basefreq was previous set to 60 Hz, even if the circuit basefreq is e.g. 50 Hz.

This fix changes this behavior so that if basefreq is not given on a line or linecode, the basefreq for that line is the circuit level basefreq.

The default basefreq for the circuit is still 60 Hz if `set defaultbasefreq` is not used; a warning is given if this command is missing.

Updates unit tests and changelog

Closes #159