### PR TITLE
ADD: Parsing of "bank" property on transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Add ability to "bank" single phase OpenDSS transformers into a single multiphase transformer (#166)
 - Add virtual line to sourcebus to model source impedance (#165)
 - Update to JuMP v0.20 / MOI v0.9 (#164)
 - Fix bug in OpenDSS parser on Lines / Linecodes related to basefreq (#163)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -3,12 +3,12 @@
 
 Parses the IOStream of a file into a Three-Phase PowerModels data structure.
 """
-function parse_file(io::IO; import_all::Bool=false, vmin::Float64=0.9, vmax::Float64=1.1, filetype="json")
+function parse_file(io::IO; import_all::Bool=false, vmin::Float64=0.9, vmax::Float64=1.1, filetype::AbstractString="json", bank_transformers::Bool=true)
     if filetype == "m"
         pmd_data = PowerModelsDistribution.parse_matlab(io)
     elseif filetype == "dss"
         Memento.warn(_LOGGER, "Not all OpenDSS features are supported, currently only minimal support for lines, loads, generators, and capacitors as shunts. Transformers and reactors as transformer branches are included, but value translation is not fully supported.")
-        pmd_data = PowerModelsDistribution.parse_opendss(io; import_all=import_all, vmin=vmin, vmax=vmax)
+        pmd_data = PowerModelsDistribution.parse_opendss(io; import_all=import_all, vmin=vmin, vmax=vmax, bank_transformers=bank_transformers)
     elseif filetype == "json"
         pmd_data = PowerModels.parse_json(io; validate=false)
     else

--- a/test/data/opendss/ut_trans_2w_yy_bank.dss
+++ b/test/data/opendss/ut_trans_2w_yy_bank.dss
@@ -1,0 +1,64 @@
+clear
+
+! Base Frequency
+Set DefaultBaseFrequency=60
+
+! New Circuit
+New circuit.ut_trans
+~ BasekV=11 BaseMVA=1 pu=1.0  ISC3=9999999999 ISC1=9999999999
+
+! Transformers
+New Transformer.TX1a windings=2 phases=1 Buses=[1.1 2.1]
+~ Conns=[Wye Wye]
+~ kVs=[11 4]
+~ kVAs=[500 500]
+~ %Rs=[1 2]
+~ xhl=5
+~ %noloadloss=5
+~ %imag=11
+~ leadlag=lead
+~ taps=[1.05 0.95]
+~ bank=TX1
+
+New Transformer.TX1b windings=2 phases=1 Buses=[1.2 2.2]
+~ Conns=[Wye Wye]
+~ kVs=[11 4]
+~ kVAs=[500 500]
+~ %Rs=[1 2]
+~ xhl=5
+~ %noloadloss=5
+~ %imag=11
+~ leadlag=lead
+~ taps=[1.02 0.97]
+~ bank=TX1
+
+New Transformer.TX1c windings=2 phases=1 Buses=[1.3 2.3]
+~ Conns=[Wye Wye]
+~ kVs=[11 4]
+~ kVAs=[500 500]
+~ %Rs=[1 2]
+~ xhl=5
+~ %noloadloss=5
+~ %imag=11
+~ leadlag=lead
+~ taps=[1.10 0.90]
+~ bank=TX1
+
+! Transmission Lines
+New Line.LINE1 Bus1=SourceBus Bus2=1 phases=3 X1=3 R1=6
+New Line.LINE2 Bus1=2 Bus2=3 phases=3 X1=0.3 R1=0.6
+
+! Loads
+New Load.LOAD1 Phases=1 Bus1=1.1 kV=6.531 kW=43 kvar=76 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD2 Phases=1 Bus1=1.2 kV=6.531 kW=52 kvar=85 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD3 Phases=1 Bus1=1.3 kV=6.531 kW=61 kvar=94 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD4 Phases=1 Bus1=3.1 kV=2.3 kW=74 kvar=41 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD5 Phases=1 Bus1=3.2 kV=2.3 kW=85 kvar=52 vminpu=0.8 vmaxpu=1.2
+New Load.LOAD6 Phases=1 Bus1=3.3 kV=2.3 kW=96 kvar=63 vminpu=0.8 vmaxpu=1.2
+
+! Set Voltage Bases
+Set voltagebases=[11  4]
+Calcvoltagebases
+
+! Solve network
+solve

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -97,4 +97,16 @@ vm(sol, pmd_data, name) = sol["solution"]["bus"][string(bus_name2id(pmd_data, na
             @test norm(va1-va2, Inf) <= 1E-3
         end
     end
+    @testset "banked transformers" begin
+        file = "../test/data/opendss/ut_trans_2w_yy_bank.dss"
+        pmd1 = PMD.parse_file(file)
+        pmd2 = PMD.parse_file(file; bank_transformers=false)
+        result1 = run_ac_mc_pf(pmd1, ipopt_solver)
+        result2 = run_ac_mc_pf(pmd2, ipopt_solver)
+
+        @test result1["termination_status"] == PMs.LOCALLY_SOLVED
+        @test result2["termination_status"] == PMs.LOCALLY_SOLVED
+        @test result1["solution"]["bus"] == result2["solution"]["bus"]
+        @test result1["solution"]["gen"] == result2["solution"]["gen"]
+    end
 end


### PR DESCRIPTION
Adds the ability to utilize the "bank" property on OpenDSS transformers. If the bank property is present, by default the OpenDSS parser will attempt to combine those transformers that have been banked by using their active phases to combine their properties into a single transformer with the "bank" property as its name.

"bank_transformers" kwarg added to `parse_file` to allow users to disable automatic banking of the transformers.

Logic of initial transformer parsing is updated to support this feature.

Added unit test to confirm that automatic banking and no banking result in the same power flow solutions.

Updated changelog.