### PR TITLE
FIX: phase order swap on lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Fix bug in OpenDSS parser on Lines where the connected phases are listed out of order (#167)
 - Add ability to "bank" single phase OpenDSS transformers into a single multiphase transformer (#166)
 - Add virtual line to sourcebus to model source impedance (#165)
 - Update to JuMP v0.20 / MOI v0.9 (#164)

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -352,6 +352,18 @@ function _isa_matrix(data::AbstractString)::Bool
 end
 
 
+"Reorders a `matrix` based on the order that phases are listed in on the from- (`pof`) and to-sides (`pot`)"
+function _reorder_matrix(matrix, pof, pot)
+    mat = deepcopy(matrix)
+    for (i, pf) in enumerate(pof)
+        for (j, pt) in enumerate(pot)
+            mat[i, j] = matrix[pf, pt]
+        end
+    end
+    return mat
+end
+
+
 """
     _parse_array(dtype, data)
 
@@ -953,16 +965,20 @@ end
 
 
 """
-    _get_conductors_ordered(busname)
+    _get_conductors_ordered(busname; neutral=true)
 
-Returns an ordered list of defined conductors.
+Returns an ordered list of defined conductors. If neutral=false, will omit any `0`
 """
-function _get_conductors_ordered(busname::AbstractString)
+function _get_conductors_ordered(busname::AbstractString; neutral=true)
     parts = split(busname, '.'; limit=2)
     ret = []
     if length(parts)==2
         conds_str = split(parts[2], '.')
-        ret = [parse(Int, i) for i in conds_str]
+        if neutral
+            ret = [parse(Int, i) for i in conds_str]
+        else
+            ret = [parse(Int, i) for i in conds_str if i != "0"]
+        end
     end
     return ret
 end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -653,6 +653,13 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         merge!(defaults, linecode)
 
         bf, nodes = _parse_busname(defaults["bus1"])
+
+        phase_order_fr = _get_conductors_ordered(defaults["bus1"]; neutral=false)
+        phase_order_to = _get_conductors_ordered(defaults["bus2"]; neutral=false)
+
+        # phase_order_fr = isempty(phase_order_fr) ? collect(1:nconductors) : phase_order_fr
+        # phase_order_to = isempty(phase_order_to) ? collect(1:nconductors) : phase_order_to
+
         bt = _parse_busname(defaults["bus2"])[1]
 
         branchDict = Dict{String,Any}()
@@ -664,9 +671,10 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
 
         branchDict["length"] = defaults["length"]
 
-        rmatrix = _parse_matrix(defaults["rmatrix"], nodes, nconductors)
-        xmatrix = _parse_matrix(defaults["xmatrix"], nodes, nconductors)
-        cmatrix = _parse_matrix(defaults["cmatrix"], nodes, nconductors)
+        rmatrix = _reorder_matrix(_parse_matrix(defaults["rmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
+        xmatrix = _reorder_matrix(_parse_matrix(defaults["xmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
+        cmatrix = _reorder_matrix(_parse_matrix(defaults["cmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
+
         Zbase = (pmd_data["basekv"] / sqrt(3))^2 * nconductors / (pmd_data["baseMVA"])
 
         Zbase = Zbase/3

--- a/test/data/opendss/case3_unbalanced_assym_swap.dss
+++ b/test/data/opendss/case3_unbalanced_assym_swap.dss
@@ -1,0 +1,37 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6 basemva=0.5
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0200    0.1000 |  0.0200    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0433    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -1  50.92958178940651 | -2 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.3.2.1.0  Primary.3.2.1.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=9   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -105,6 +105,16 @@
         @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00932693; atol=1e-4)
     end
 
+    @testset "3-bus unbalanced w/ assymetric linecode & phase order swap" begin
+        pmd = PMD.parse_file("../test/data/opendss/case3_unbalanced_assym_swap.dss")
+        sol = PMD.run_ac_mc_pf(pmd, ipopt_solver)
+
+        @test sol["termination_status"] == PMs.LOCALLY_SOLVED
+
+        @test all(isapprox.(sol["solution"]["bus"]["2"]["vm"], [0.983453, 0.98718, 0.981602]; atol=1e-5))
+        @test all(isapprox.(sol["solution"]["bus"]["2"]["va"], deg2rad.([-0.07, -120.19, 120.29]); atol=1e-2))
+    end
+
     @testset "5-bus 3-phase ac pf case" begin
         mp_data = PMD.parse_file("../test/data/opendss/case5_phase_drop.dss")
         result = run_mc_pf(mp_data, PMs.ACPPowerModel, ipopt_solver)


### PR DESCRIPTION
In OpenDSS, the order of phases can be swaped on lines, e.g. `bus1=a.1.2.3 bus2=b.1.2.3` vs `bus1=a.3.2.1 bus2=b.3.2.1`. This has the effect of reordering the line property matrices, i.e. `rmatrix`, `xmatrix`, and `cmatrix`.

This PR accounts for this change by obtaining the phase connections in the order that they appear and reordering the matrices accordingly.

Adds a unit test and updates changelog