### PR TITLE
REF: Rename :trans, "trans", _trans_ to 'transformer'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Rename "trans" in data and ref to `transformer` for component naming consistency (breaking) (#169)
 - Change internal variable and constraint functions to loop over phases internally (breaking) (#168)
 - Fix bug in OpenDSS parser on Lines where the connected phases are listed out of order (#167)
 - Add ability to "bank" single phase OpenDSS transformers into a single multiphase transformer (#166)

--- a/docs/src/specifications.md
+++ b/docs/src/specifications.md
@@ -20,7 +20,7 @@ for c in PMs.conductor_ids(pm)
     PMs.variable_generation(pm, cnd=c)
     PMs.variable_dcline_flow(pm, cnd=c)
 end
-variable_mc_trans_flow(pm)
+variable_mc_transformer_flow(pm)
 variable_mc_oltc_tap(pm)
 ```
 
@@ -78,7 +78,7 @@ for c in PMs.conductor_ids(pm)
     PMs.variable_generation(pm, cnd=c)
     PMs.variable_dcline_flow(pm, cnd=c)
 end
-variable_mc_trans_flow(pm)
+variable_mc_transformer_flow(pm)
 variable_mc_oltc_tap(pm)
 ```
 
@@ -138,7 +138,7 @@ Unlike `mc_pf`, which models all loads as constant power loads, this problem spe
 ```julia
 variable_mc_voltage(pm, bounded=false)
 variable_mc_branch_flow(pm, bounded=false)
-variable_mc_trans_flow(pm, bounded=false)
+variable_mc_transformer_flow(pm, bounded=false)
 variable_mc_load(pm)
 
 for c in PMs.conductor_ids(pm)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -202,14 +202,14 @@ function constraint_mc_trans(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw
     if _PMs.ref(pm, pm.cnw, :conductors)!=3
         Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
-    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_mc_trans_Tvi(pm, i)
-    f_bus = _PMs.ref(pm, :trans, i)["f_bus"]
-    t_bus = _PMs.ref(pm, :trans, i)["t_bus"]
-    tm = _PMs.ref(pm, :trans, i)["tm"]
-    constraint_mc_trans_voltage(pm, nw, i, f_bus, t_bus, tm, Tv_fr, Tv_im, Cv_to)
+    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_mc_transformer_Tvi(pm, i)
+    f_bus = _PMs.ref(pm, :transformer, i)["f_bus"]
+    t_bus = _PMs.ref(pm, :transformer, i)["t_bus"]
+    tm = _PMs.ref(pm, :transformer, i)["tm"]
+    constraint_mc_transformer_voltage(pm, nw, i, f_bus, t_bus, tm, Tv_fr, Tv_im, Cv_to)
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
-    constraint_mc_trans_flow(pm, nw, i, f_bus, t_bus, f_idx, t_idx, tm, Ti_fr, Ti_im, Cv_to)
+    constraint_mc_transformer_flow(pm, nw, i, f_bus, t_bus, f_idx, t_idx, tm, Ti_fr, Ti_im, Cv_to)
 end
 
 
@@ -218,8 +218,8 @@ function constraint_mc_oltc(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     if _PMs.ref(pm, pm.cnw, :conductors)!=3
         Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
-    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_mc_trans_Tvi(pm, i)
-    trans = _PMs.ref(pm, :trans, i)
+    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_mc_transformer_Tvi(pm, i)
+    trans = _PMs.ref(pm, :transformer, i)
     f_bus = trans["f_bus"]
     t_bus = trans["t_bus"]
     constraint_mc_oltc_voltage(pm, nw, i, f_bus, t_bus, Tv_fr, Tv_im, Cv_to)
@@ -227,7 +227,7 @@ function constraint_mc_oltc(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     t_idx = (i, t_bus, f_bus)
     constraint_mc_oltc_flow(pm, nw, i, f_bus, t_bus, f_idx, t_idx, Ti_fr, Ti_im, Cv_to)
     # fix the taps with a constraint which are not free
-    trans = _PMs.ref(pm, :trans, i)
+    trans = _PMs.ref(pm, :transformer, i)
     fixed = trans["fixed"]
     tm = trans["tm"]
     constraint_mc_oltc_tap_fix(pm, i, fixed, tm)

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -43,14 +43,14 @@ end
 
 "Adds arcs for PMD transformers; for dclines and branches this is done in PMs"
 function ref_add_arcs_trans!(pm::_PMs.AbstractPowerModel)
-    if !haskey(_PMs.ref(pm, pm.cnw), :trans)
+    if !haskey(_PMs.ref(pm, pm.cnw), :transformer)
         # this might happen when parsing data from matlab format
         # the OpenDSS parser always inserts a trans dict
-        _PMs.ref(pm, pm.cnw)[:trans] = Dict{Int, Any}()
+        _PMs.ref(pm, pm.cnw)[:transformer] = Dict{Int, Any}()
     end
     # dirty fix add arcs_from/to_trans and bus_arcs_trans
-    pm.ref[:nw][0][:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in _PMs.ref(pm, :trans)]
-    pm.ref[:nw][0][:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in _PMs.ref(pm, :trans)]
+    pm.ref[:nw][0][:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in _PMs.ref(pm, :transformer)]
+    pm.ref[:nw][0][:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in _PMs.ref(pm, :transformer)]
     pm.ref[:nw][0][:arcs_trans] = [pm.ref[:nw][0][:arcs_from_trans]..., pm.ref[:nw][0][:arcs_to_trans]...]
     pm.ref[:nw][0][:bus_arcs_trans] = Dict{Int64, Array{Any, 1}}()
     for i in _PMs.ids(pm, :bus)
@@ -60,8 +60,8 @@ end
 
 
 ""
-function _calc_mc_trans_Tvi(pm::_PMs.AbstractPowerModel, i::Int; nw=pm.cnw)
-    trans = _PMs.ref(pm, nw, :trans,  i)
+function _calc_mc_transformer_Tvi(pm::_PMs.AbstractPowerModel, i::Int; nw=pm.cnw)
+    trans = _PMs.ref(pm, nw, :transformer,  i)
     # transformation matrices
     # Tv and Ti will be compositions of these
     Tbr = [0 0 1; 1 0 0; 0 1 0]                             # barrel roll

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -140,14 +140,14 @@ end
 
 
 "Creates variables for both `active` and `reactive` power flow at each transformer."
-function variable_mc_trans_flow(pm::_PMs.AbstractPowerModel; kwargs...)
-    variable_mc_trans_active_flow(pm; kwargs...)
-    variable_mc_trans_reactive_flow(pm; kwargs...)
+function variable_mc_transformer_flow(pm::_PMs.AbstractPowerModel; kwargs...)
+    variable_mc_transformer_active_flow(pm; kwargs...)
+    variable_mc_transformer_reactive_flow(pm; kwargs...)
 end
 
 
 "Create variables for the active power flowing into all transformer windings."
-function variable_mc_trans_active_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, bounded=true)
+function variable_mc_transformer_active_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, bounded=true)
     for cnd in _PMs.conductor_ids(pm)
         _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
             [(l,i,j) in _PMs.ref(pm, nw, :arcs_trans)],
@@ -157,8 +157,8 @@ function variable_mc_trans_active_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm.c
         if bounded
             for arc in _PMs.ref(pm, nw, :arcs_trans)
                 tr_id = arc[1]
-                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  =  _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_lb  = -_PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
+                flow_ub  =  _PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
                 JuMP.set_lower_bound(_PMs.var(pm, nw, cnd, :pt, arc), flow_lb)
                 JuMP.set_upper_bound(_PMs.var(pm, nw, cnd, :pt, arc), flow_ub)
             end
@@ -168,7 +168,7 @@ end
 
 
 "Create variables for the reactive power flowing into all transformer windings."
-function variable_mc_trans_reactive_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+function variable_mc_transformer_reactive_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
     for cnd in _PMs.conductor_ids(pm)
         _PMs.var(pm, nw, cnd)[:qt] = JuMP.@variable(pm.model,
             [(l,i,j) in _PMs.ref(pm, nw, :arcs_trans)],
@@ -178,8 +178,8 @@ function variable_mc_trans_reactive_flow(pm::_PMs.AbstractPowerModel; nw::Int=pm
         if bounded
             for arc in _PMs.ref(pm, nw, :arcs_trans)
                 tr_id = arc[1]
-                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  = _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_lb  = -_PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
+                flow_ub  = _PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
                 JuMP.set_lower_bound(_PMs.var(pm, nw, cnd, :qt, arc), flow_lb)
                 JuMP.set_upper_bound(_PMs.var(pm, nw, cnd, :qt, arc), flow_ub)
             end
@@ -191,17 +191,17 @@ end
 "Create tap variables."
 function variable_mc_oltc_tap(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, bounded=true)
     nphases = 3
-    oltc_ids = _PMs.ids(pm, pm.cnw, :trans)
+    oltc_ids = _PMs.ids(pm, pm.cnw, :transformer)
     for c in 1:nphases
         _PMs.var(pm, nw, c)[:tap] = JuMP.@variable(pm.model,
             [i in oltc_ids],
             base_name="$(nw)_tm",
-            start=_PMs.ref(pm, nw, :trans, i, "tm")[c]
+            start=_PMs.ref(pm, nw, :transformer, i, "tm")[c]
         )
         if bounded
             for tr_id in oltc_ids
-                JuMP.set_lower_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :trans, tr_id, "tm_min")[c])
-                JuMP.set_upper_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :trans, tr_id, "tm_max")[c])
+                JuMP.set_lower_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :transformer, tr_id, "tm_min")[c])
+                JuMP.set_upper_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :transformer, tr_id, "tm_max")[c])
             end
         end
     end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -262,7 +262,7 @@ end
 
 
 "Links the voltage at both windings of a fixed tap transformer"
-function constraint_mc_trans_voltage(pm::_PMs.AbstractACPModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
+function constraint_mc_transformer_voltage(pm::_PMs.AbstractACPModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
     ncnd  = 3
     # from side
     vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
@@ -287,7 +287,7 @@ end
 
 
 "Links the power flowing into both windings of a fixed tap transformer"
-function constraint_mc_trans_flow(pm::_PMs.AbstractACPModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
+function constraint_mc_transformer_flow(pm::_PMs.AbstractACPModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
     ncnd  = 3
     # from side variables
     vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
@@ -484,9 +484,9 @@ end
 
 
 "Links the power flowing into both windings of a variable tap transformer."
-function constraint_mc_trans_flow_var(pm::_PMs.AbstractPowerModel, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, Ti_fr, Ti_im; nw::Int=pm.cnw)
+function constraint_mc_transformer_flow_var(pm::_PMs.AbstractPowerModel, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, Ti_fr, Ti_im; nw::Int=pm.cnw)
     # for ac formulation, indentical to fixed tap
-    constraint_mc_trans_flow(pm, i, f_bus, t_bus, f_idx, t_idx, Ti_fr, Ti_im)
+    constraint_mc_transformer_flow(pm, i, f_bus, t_bus, f_idx, t_idx, Ti_fr, Ti_im)
 end
 
 

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -1,7 +1,7 @@
 ### generic features that apply to all active-power-only (apo) approximations
 
 "do nothing, no reactive power in this model"
-function variable_mc_trans_reactive_flow(pm::_PMs.AbstractActivePowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+function variable_mc_transformer_reactive_flow(pm::_PMs.AbstractActivePowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
 end
 
 

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -73,12 +73,12 @@ end
 
 
 "nothing to do, no voltage variables"
-function constraint_mc_trans_voltage(pm::LPLinUBFModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
+function constraint_mc_transformer_voltage(pm::LPLinUBFModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
 end
 
 
 "nothing to do, this model is symmetric"
-function constraint_mc_trans_flow(pm::LPLinUBFModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
+function constraint_mc_transformer_flow(pm::LPLinUBFModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
 end
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -17,7 +17,7 @@ end
 
 ######## Lossless Models ########
 "Create variables for the active power flowing into all transformer windings"
-function variable_mc_trans_active_flow(pm::_PMs.AbstractAPLossLessModels; nw::Int=pm.cnw, bounded=true)
+function variable_mc_transformer_active_flow(pm::_PMs.AbstractAPLossLessModels; nw::Int=pm.cnw, bounded=true)
     for cnd in _PMs.conductor_ids(pm)
         pt = _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
             [(l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)],
@@ -27,8 +27,8 @@ function variable_mc_trans_active_flow(pm::_PMs.AbstractAPLossLessModels; nw::In
         if bounded
             for arc in _PMs.ref(pm, nw, :arcs_from_trans)
                 tr_id = arc[1]
-                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  =  _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_lb  = -_PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
+                flow_ub  =  _PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
                 JuMP.set_lower_bound(pt[arc], flow_lb)
                 JuMP.set_upper_bound(pt[arc], flow_ub)
             end
@@ -106,12 +106,12 @@ end
 
 
 "nothing to do, no voltage variables"
-function constraint_mc_trans_voltage(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
+function constraint_mc_transformer_voltage(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
 end
 
 
 "nothing to do, this model is symmetric"
-function constraint_mc_trans_flow(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
+function constraint_mc_transformer_flow(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
 end
 
 

--- a/src/prob/debug.jl
+++ b/src/prob/debug.jl
@@ -29,7 +29,7 @@ function post_mc_opf_pbs(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
 
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     variable_mc_bus_power_slack(pm)
 
@@ -75,7 +75,7 @@ function post_mc_pf_pbs(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm, bounded=false)
 
     variable_mc_branch_flow(pm, bounded=false)
-    variable_mc_trans_flow(pm, bounded=false)
+    variable_mc_transformer_flow(pm, bounded=false)
 
     variable_mc_bus_power_slack(pm)
 

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -55,7 +55,7 @@ function post_mc_mld(pm::_PMs.AbstractPowerModel)
     variable_mc_bus_voltage_on_off(pm)
 
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=true)
 
@@ -98,7 +98,7 @@ function post_mc_mld(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 
@@ -112,7 +112,7 @@ function post_mc_mld_strg(pm::_PMs.AbstractPowerModel)
     variable_mc_bus_voltage_on_off(pm)
 
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=true)
 
@@ -169,7 +169,7 @@ function post_mc_mld_strg(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 
@@ -184,7 +184,7 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
 
     variable_mc_branch_current(pm)
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=true)
 
@@ -228,7 +228,7 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 
@@ -242,7 +242,7 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
     variable_mc_bus_voltage_on_off(pm)
 
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=false)
 
@@ -286,7 +286,7 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -20,7 +20,7 @@ end
 function post_mc_opf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
@@ -52,7 +52,7 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 

--- a/src/prob/opf_bctr.jl
+++ b/src/prob/opf_bctr.jl
@@ -14,7 +14,7 @@ end
 function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
@@ -51,7 +51,7 @@ function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 

--- a/src/prob/opf_lm.jl
+++ b/src/prob/opf_lm.jl
@@ -24,7 +24,7 @@ delta-connected and wye-connected
 function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
     variable_mc_load(pm)
 
     for c in _PMs.conductor_ids(pm)
@@ -62,7 +62,7 @@ function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -25,7 +25,7 @@ function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
         _PMs.variable_generation(pm, cnd=c)
         _PMs.variable_dcline_flow(pm, cnd=c)
     end
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
     variable_mc_oltc_tap(pm)
 
     constraint_mc_model_voltage(pm)
@@ -53,7 +53,7 @@ function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_oltc(pm, i)
     end
 

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -26,7 +26,7 @@ end
 function post_mc_pf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm, bounded=false)
     variable_mc_branch_flow(pm, bounded=false)
-    variable_mc_trans_flow(pm, bounded=false)
+    variable_mc_transformer_flow(pm, bounded=false)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, bounded=false, cnd=c)
@@ -81,7 +81,7 @@ function post_mc_pf(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 end

--- a/src/prob/pf_lm.jl
+++ b/src/prob/pf_lm.jl
@@ -26,7 +26,7 @@ end
 function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm, bounded=false)
     variable_mc_branch_flow(pm, bounded=false)
-    variable_mc_trans_flow(pm, bounded=false)
+    variable_mc_transformer_flow(pm, bounded=false)
     variable_mc_load(pm, bounded=false)
 
     for c in _PMs.conductor_ids(pm)
@@ -86,7 +86,7 @@ function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 end

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -21,7 +21,7 @@ end
 function post_mc_strg_opf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
-    variable_mc_trans_flow(pm)
+    variable_mc_transformer_flow(pm)
     variable_mc_storage(pm)
 
     for c in _PMs.conductor_ids(pm)
@@ -63,7 +63,7 @@ function post_mc_strg_opf(pm::_PMs.AbstractPowerModel)
         _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in _PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -130,7 +130,7 @@
         # if rs=0, then 1 extra, else 3 extra
         # tr1:+1(rs=0), tr2:+3, tr3:+1(rs=0), tr4:+3, tr5:+1(rs=0)
         # 10 transformers, 2 per dss transformer
-        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "trans"], [33, 4, 5, 27, 4, 0, 10])
+        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer"], [33, 4, 5, 27, 4, 0, 10])
             @test haskey(pmd, key)
             @test length(pmd[key]) == len
         end
@@ -251,7 +251,7 @@
 
             @test pmd["branch"]["1"]["source_id"] == "line.l1" && length(pmd["branch"]["1"]["active_phases"]) == 3
             # transformer is no longer a branch
-            @test pmd["trans"]["1"]["source_id"] == "transformer.t4_1"  # winding indicated by _1
+            @test pmd["transformer"]["1"]["source_id"] == "transformer.t4_1"  # winding indicated by _1
             # updated index, reactors shifted
             @test pmd["branch"]["10"]["source_id"] == "reactor.reactor1" && length(pmd["branch"]["10"]["active_phases"]) == 3
 

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -31,8 +31,8 @@ vm(sol, pmd_data, name) = sol["solution"]["bus"][string(bus_name2id(pmd_data, na
             file = "../test/data/opendss/ut_trans_2w_yy_oltc.dss"
             pmd_data = PMD.parse_file(file)
             # free the taps
-            pmd_data["trans"]["1"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
-            pmd_data["trans"]["2"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
+            pmd_data["transformer"]["1"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
+            pmd_data["transformer"]["2"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
             pm = PMs.build_model(pmd_data, PMs.ACPPowerModel, PMD.post_mc_opf_oltc, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
             sol = PMs.optimize_model!(pm, ipopt_solver)
             # check that taps are set as to boost the voltage in the branches as much as possible;


### PR DESCRIPTION
For consistency with "branch", rename instances of :trans in ref and "trans" in data dictionary to :transformer and "transformer", respectively.

Also renames constraint and variable functions for same consistency.

Internal variables, i.e. those used inside functions, are not changed, and neither are filenames, as both of these should be largely invisible to users.

Updates changelog