### PR TITLE
FIX: apply OpenDSS properties in order written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Fix bug in OpenDSS parser where properties were not applied in the order they were received (#170)
 - Rename "trans" in data and ref to `transformer` for component naming consistency (breaking) (#169)
 - Change internal variable and constraint functions to loop over phases internally (breaking) (#168)
 - Fix bug in OpenDSS parser on Lines where the connected phases are listed out of order (#167)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -23,7 +23,7 @@ properties. DEPRECIATED: Calculation all done inside of _create_line() due to Rg
 Xg. Merge linecode values into line kwargs values BEFORE calling _create_line().
 This is now mainly used for parsing linecode dicts into correct data types.
 """
-function _create_linecode(name::AbstractString; kwargs...)
+function _create_linecode(name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :nphases, 3)
     circuit_basefreq = get(kwargs, :circuit_basefreq, 60.0)
@@ -118,7 +118,7 @@ Creates a Dict{String,Any} containing all of the properties for a Line. See
 OpenDSS documentation for valid fields and ways to specify the different
 properties.
 """
-function _create_line(bus1, bus2, name::AbstractString; kwargs...)
+function _create_line(bus1="", bus2="", name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :phases, 3)
     circuit_basefreq = get(kwargs, :circuit_basefreq, 60.0)
@@ -244,7 +244,7 @@ Creates a Dict{String,Any} containing all of the expected properties for a
 Load. See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
-function _create_load(bus1, name::AbstractString; kwargs...)
+function _create_load(bus1="", name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     kv = get(kwargs, :kv, 12.47)
     kw = get(kwargs, :kw, 10.0)
@@ -330,7 +330,7 @@ Creates a Dict{String,Any} containing all of the expected properties for a
 Generator. See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
-function _create_generator(bus1, name::AbstractString; kwargs...)
+function _create_generator(bus1="", name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     conn = get(kwargs, :conn, "wye")
 
@@ -396,7 +396,7 @@ Capacitor. If `bus2` is not specified, the capacitor will be treated as a shunt.
 See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
-function _create_capacitor(bus1, name::AbstractString, bus2=0; kwargs...)
+function _create_capacitor(bus1="", name::AbstractString="", bus2=0; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :phases, 3)
 
@@ -433,7 +433,7 @@ Reactor. If `bus2` is not specified Reactor is treated like a shunt. See
 OpenDSS documentation for valid fields and ways to specify the different
 properties.
 """
-function _create_reactor(bus1, name::AbstractString, bus2=""; kwargs...)
+function _create_reactor(bus1="", name::AbstractString="", bus2=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     phases = get(kwargs, :phases, 3)
     kvar = get(kwargs, :kvar, 1200.0)
@@ -578,7 +578,7 @@ generator. Mostly used as `sourcebus` which represents the circuit. See
 OpenDSS documentation for valid fields and ways to specify the different
 properties.
 """
-function _create_vsource(bus1, name::AbstractString, bus2=0; kwargs...)
+function _create_vsource(bus1="", name::AbstractString="", bus2=0; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     x1r1 = get(kwargs, :x1r1, 4.0)
     x0r0 = get(kwargs, :x0r0, 3.0)
@@ -793,7 +793,7 @@ Creates a Dict{String,Any} containing all of the expected properties for a
 Transformer. See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
-function _create_transformer(name::AbstractString; kwargs...)
+function _create_transformer(name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     windings = get(kwargs, :windings, 2)
     phases = get(kwargs, :phases, 3)
@@ -920,7 +920,7 @@ PVSystem. See OpenDSS document
 https://github.com/tshort/OpenDSS/blob/master/Doc/OpenDSS%20PVSystem%20Model.doc
 for valid fields and ways to specify the different properties.
 """
-function _create_pvsystem(bus1, name::AbstractString; kwargs...)
+function _create_pvsystem(bus1="", name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
     kv = get(kwargs, :kv, 12.47)
     kw = get(kwargs, :kw, 10.0)
@@ -998,7 +998,7 @@ Creates a Dict{String,Any} containing all expected properties for a storage
 element. See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
-function _create_storage(bus1, name::AbstractString; kwargs...)
+function _create_storage(bus1="", name::AbstractString=""; kwargs...)
     kwargs = Dict{Symbol,Any}(kwargs)
 
     storage = Dict{String,Any}("name" => name,
@@ -1050,22 +1050,24 @@ end
 
 "Returns a Dict{String,Type} for the desired component `comp`, giving all of the expected data types"
 function _get_dtypes(comp::AbstractString)::Dict
-    default_dicts = Dict{String,Any}("line" => _create_line("", "", ""),
-                                     "load" => _create_load("", ""),
-                                     "generator" => _create_generator("", ""),
-                                     "capacitor" => _create_capacitor("", "", ""),
-                                     "reactor" => _create_reactor("", "", ""),
-                                     "transformer" => _create_transformer(""),
-                                     "linecode" => _create_linecode(""),
-                                     "circuit" => _create_vsource("", ""),
-                                     "pvsystem" => _create_pvsystem("", ""),
-                                     "vsource" => _create_vsource("", "", ""),
-                                     "storage" => _create_storage("", "")
-                                    )
-
-    return Dict{String,Type}((k, typeof(v)) for (k, v) in default_dicts[comp])
+    return Dict{String,Type}((k, typeof(v)) for (k, v) in _constructors[comp]())
 end
 
 
 ""
 _get_dtypes(comp::String, key::String)::Type = _get_dtypes(comp)[key]
+
+
+"list of constructor functions for easy access"
+const _constructors = Dict{String,Any}("line" => _create_line,
+                                       "load" => _create_load,
+                                       "generator" => _create_generator,
+                                       "capacitor" => _create_capacitor,
+                                       "reactor" => _create_reactor,
+                                       "transformer" => _create_transformer,
+                                       "linecode" => _create_linecode,
+                                       "circuit" => _create_vsource,
+                                       "pvsystem" => _create_pvsystem,
+                                       "vsource" => _create_vsource,
+                                       "storage" => _create_storage
+                                       )

--- a/test/data/opendss/case3_balanced_prop-order.dss
+++ b/test/data/opendss/case3_balanced_prop-order.dss
@@ -1,0 +1,36 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM  rmatrix=( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000) length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  like=OHLine linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -270,6 +270,20 @@
                 end
             end
         end
+
+        @testset "order of properties on line" begin
+            pmd1 = PMD.parse_file("../test/data/opendss/case3_balanced.dss")
+            pmd2 = PMD.parse_file("../test/data/opendss/case3_balanced_prop-order.dss")
+
+            @test pmd1 == pmd2
+
+            dss1 = PMD.parse_dss("../test/data/opendss/case3_balanced.dss")
+            dss2 = PMD.parse_dss("../test/data/opendss/case3_balanced_prop-order.dss")
+
+            @test dss1 != dss2
+            @test all(a == b for (a, b) in zip(dss2["line"][1]["prop_order"],["name", "bus1", "bus2", "linecode", "rmatrix", "length"]))
+            @test all(a == b for (a, b) in zip(dss2["line"][2]["prop_order"],["name", "bus1", "bus2", "like", "linecode", "length"]))
+        end
     end
 
     @testset "2-bus diagonal" begin


### PR DESCRIPTION
In OpenDSS, properties are applied to their respective objects in the order they are written, which means `linecode=x, r0=1` is different than `r0=1 linecode=x`, but until now PowerModelsDistribution applied properties in a fixed order of, `like` then `linecode`, overwriting properties that shouldn't have been overwritten.

Adds additional parsing functions to make this possible. In `parse_dss`, the order properties are entered is now retained in `"prop_order"`, which is used during the conversion to the internal data format.

In OpenDSS, `like` should be applied at the beginning of a line, but its application doesn't seem consistent with the manual, so if it is not
one of the first properties given, a warning is thrown by PowerModelsDistribution that PMD will treat the `like` property as having appeared before all other keywords.

Updates changelog and adds unit test.

Closes #131