### PR TITLE
FIX: OpenDSS parsing bugs

### DIFF
--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -353,11 +353,11 @@ end
 
 
 "Reorders a `matrix` based on the order that phases are listed in on the from- (`pof`) and to-sides (`pot`)"
-function _reorder_matrix(matrix, pof, pot)
-    mat = deepcopy(matrix)
-    for (i, pf) in enumerate(pof)
-        for (j, pt) in enumerate(pot)
-            mat[i, j] = matrix[pf, pt]
+function _reorder_matrix(matrix, nconductors, phase_order)
+    mat = fill(0.0, nconductors, nconductors)
+    for (i, n) in enumerate(phase_order)
+        for (j, m) in enumerate(phase_order)
+            mat[n, m] = matrix[i, j]
         end
     end
     return mat

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -355,9 +355,16 @@ end
 "Reorders a `matrix` based on the order that phases are listed in on the from- (`pof`) and to-sides (`pot`)"
 function _reorder_matrix(matrix, nconductors, phase_order)
     mat = fill(0.0, nconductors, nconductors)
-    for (i, n) in enumerate(phase_order)
-        for (j, m) in enumerate(phase_order)
-            mat[n, m] = matrix[i, j]
+    if isempty(phase_order)
+        # sometimes the conductors are not explicitly supplied;
+        # in that case, place matrix in the upper left corner of mat
+        N, M = size(matrix)
+        mat[1:N, 1:M] = matrix
+    else
+        for (i, n) in enumerate(phase_order)
+            for (j, m) in enumerate(phase_order)
+                mat[n, m] = matrix[i, j]
+            end
         end
     end
     return mat

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -628,6 +628,7 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
 
         phase_order_fr = _get_conductors_ordered(defaults["bus1"]; neutral=false)
         phase_order_to = _get_conductors_ordered(defaults["bus2"]; neutral=false)
+        @assert(all(phase_order_fr.==phase_order_to))
 
         # phase_order_fr = isempty(phase_order_fr) ? collect(1:nconductors) : phase_order_fr
         # phase_order_to = isempty(phase_order_to) ? collect(1:nconductors) : phase_order_to
@@ -643,9 +644,9 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
 
         branchDict["length"] = defaults["length"]
 
-        rmatrix = _reorder_matrix(_parse_matrix(defaults["rmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
-        xmatrix = _reorder_matrix(_parse_matrix(defaults["xmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
-        cmatrix = _reorder_matrix(_parse_matrix(defaults["cmatrix"], nodes, nconductors), phase_order_fr, phase_order_to)
+        rmatrix = _reorder_matrix(defaults["rmatrix"], nconductors, phase_order_fr)
+        xmatrix = _reorder_matrix(defaults["xmatrix"], nconductors, phase_order_fr)
+        cmatrix = _reorder_matrix(defaults["cmatrix"], nconductors, phase_order_fr)
 
         Zbase = (pmd_data["basekv"] / sqrt(3))^2 * nconductors / (pmd_data["baseMVA"])
 


### PR DESCRIPTION
There were some issues with the parser changes
1. When a bank has the same name as a transformer, the parser got stuck in a loop. I updated the banking code to prevent this, and fixed the merging as well (transformer_comp values are indexed on winding and conductor, not only conductor).
2. The branch phase reordering was not working as it should.

I am still investigating some other issues