### PR TITLE
FIX: setting source values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Fix bug in OpenDSS circuit initialization (vsource) (#178)
+- Make current rating (c_rating_a|b|c) be the default on branches (breaking)
 - Fix bug in transformer `ref` extension where all refs were not built for all `nw` in multinetworks (#171)
 - Fix bug in OpenDSS parser where properties were not applied in the order they were received (#170)
 - Rename "trans" in data and ref to `transformer` for component naming consistency (breaking) (#169)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -596,8 +596,8 @@ function _create_vsource(bus1="", name::AbstractString="", bus2=0; kwargs...)
     mvasc3 = get(kwargs, :mvasc3, 2000.0)
     mvasc1 = get(kwargs, :mvasc1, 2100.0)
 
-    isc3 = get(kwargs, :isc3, 10000.0)
-    isc1 = get(kwargs, :isc1, 10500.0)
+    isc3 = get(kwargs, :isc3, 10041.0)
+    isc1 = get(kwargs, :isc1, 10543.0)
 
     r1 = get(kwargs, :r1, 1.65)
     x1 = get(kwargs, :x1, 6.6)
@@ -618,19 +618,13 @@ function _create_vsource(bus1="", name::AbstractString="", bus2=0; kwargs...)
 
     Zbase = basekv^2 / basemva
 
-    if (haskey(kwargs, :mvasc3) && haskey(kwargs, :mvasc1)) || (haskey(kwargs, :isc3) && haskey(kwargs, :isc1))
-        if haskey(kwargs, :mvasc3) && haskey(kwargs, :mvasc1)
-            mvasc3 = kwargs[:mvasc3]
-            mvasc1 = kwargs[:mvasc1]
-
-            isc3 = mvasc3 * 1e3 / (basekv * sqrt(3.0))
-            isc1 = mvasc1 * 1e3 / (basekv * factor)
-        elseif haskey(kwargs, :isc3) && haskey(kwargs, :isc1)
-            isc3 = kwargs[:isc3]
-            isc1 = kwargs[:isc1]
-
-            mvasc3 = sqrt(3) * basekv * isc3 / 1e3
-            mvasc1 = factor * basekv * isc1 / 1e3
+    if (haskey(kwargs, :mvasc3) || haskey(kwargs, :mvasc1)) || (haskey(kwargs, :isc3) || haskey(kwargs, :isc1))
+        if haskey(kwargs, :mvasc3) || haskey(kwargs, :mvasc1)
+            isc3 = haskey(kwargs, :mvasc3) ? mvasc3 * 1e3 / (basekv * sqrt(3.0)) : isc3
+            isc1 = haskey(kwargs, :mvasc1) ? mvasc1 * 1e3 / (basekv * factor) : isc1
+        elseif haskey(kwargs, :isc3) || haskey(kwargs, :isc1)
+            mvasc3 = haskey(kwargs, :isc3) ? sqrt(3) * basekv * isc3 / 1e3 : mvasc3
+            mvasc1 = haskey(kwargs, :isc1) ? factor * basekv * isc1 / 1e3 : mvasc1
         end
 
         x1 = basekv^2 / mvasc3 / sqrt(1.0 + 1.0 / x1r1^2)

--- a/test/data/opendss/test_simple.dss
+++ b/test/data/opendss/test_simple.dss
@@ -2,6 +2,7 @@
 
 
 new circuit.Simple
+~ mVAsc3=1900
 
 new line.branch1 bus1=sourcebus bus2=2
 

--- a/test/data/opendss/test_simple3.dss
+++ b/test/data/opendss/test_simple3.dss
@@ -1,4 +1,5 @@
 new object=circuit.test3
+~ isc3=9538.8
 
 new line.l1 bus1=sourcebus bus2=b1
 

--- a/test/data/opendss/test_simple4.dss
+++ b/test/data/opendss/test_simple4.dss
@@ -1,3 +1,4 @@
 new circuit.c1
+~ isc1=10500
 
 new transformer.t1 windings=3 phases=3 buses=(sourcebus, b1, b2)

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -266,6 +266,35 @@
         @test all(a == b for (a, b) in zip(dss2["line"][1]["prop_order"],["name", "bus1", "bus2", "linecode", "rmatrix", "length"]))
         @test all(a == b for (a, b) in zip(dss2["line"][2]["prop_order"],["name", "bus1", "bus2", "like", "linecode", "length"]))
     end
+
+    @testset "opendss parse verify mvasc3/mvasc1 circuit parse" begin
+        dss = PMD.parse_dss("../test/data/opendss/test_simple.dss")
+        PMD.parse_dss_with_dtypes!(dss, ["circuit"])
+        circuit = PMD._create_vsource("sourcebus", "simple"; PMD._to_sym_keys(dss["circuit"][1])...)
+
+        @test circuit["mvasc1"] == 2100.0
+        @test circuit["mvasc3"] == 1900.0
+        @test isapprox(circuit["isc3"], 9538.8; atol=1e-1)
+        @test isapprox(circuit["isc1"], 10543.0; atol=1e-1)
+
+        dss = PMD.parse_dss("../test/data/opendss/test_simple3.dss")
+        PMD.parse_dss_with_dtypes!(dss, ["circuit"])
+        circuit = PMD._create_vsource("sourcebus", "simple"; PMD._to_sym_keys(dss["circuit"][1])...)
+
+        @test circuit["mvasc1"] == 2100.0
+        @test isapprox(circuit["mvasc3"], 1900.0; atol=1e-1)
+        @test circuit["isc3"] == 9538.8
+        @test isapprox(circuit["isc1"], 10543.0; atol=1e-1)
+
+        dss = PMD.parse_dss("../test/data/opendss/test_simple4.dss")
+        PMD.parse_dss_with_dtypes!(dss, ["circuit"])
+        circuit = PMD._create_vsource("sourcebus", "simple"; PMD._to_sym_keys(dss["circuit"][1])...)
+
+        @test isapprox(circuit["mvasc1"], 2091.5; atol=1e-1)
+        @test circuit["mvasc3"] == 2000.0
+        @test circuit["isc3"] == 10041.0
+        @test circuit["isc1"] == 10500.0
+    end
 end
 
 @testset "test json parser" begin


### PR DESCRIPTION
Fixes the creation of vsource from circuit to use correct values for mvasc3,mvasc1 and isc3,isc1  if one of the pair is not specified.

Default values in documentation are not consistent with software for ISC(1|3)

Updates unit tests and changelog

Closes #176