### PR TITLE
REF: Make constraint_mc_power_balance generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Moved storage to main MLD and OPF problems (#179)
+- Refactor to remove dcline variables and constraints (#179)
+- Refactor to genericize `constraint_mc_power_balance` (#179)
 - Fix bug in OpenDSS circuit initialization (vsource) (#178)
 - Make current rating (c_rating_a|b|c) be the default on branches (breaking)
 - Fix bug in transformer `ref` extension where all refs were not built for all `nw` in multinetworks (#171)

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -10,39 +10,8 @@ function objective_min_bus_power_slack(pm::_PMs.AbstractPowerModel)
 end
 
 
-"minimum load delta objective (continuous load shed)"
-function objective_mc_min_load_delta(pm::_PMs.AbstractPowerModel)
-    for (n, nw_ref) in _PMs.nws(pm)
-        for c in _PMs.conductor_ids(pm, n)
-            _PMs.var(pm, n, c)[:delta_pg] = JuMP.@variable(pm.model,
-                [i in _PMs.ids(pm, n, :gen)], base_name="$(n)_$(c)_delta_pg",
-                start = 0.0
-            )
-            for (i, gen) in nw_ref[:gen]
-                JuMP.@constraint(pm.model, _PMs.var(pm, n, c, :delta_pg, i) >=  (gen["pg"][c] - _PMs.var(pm, n, c, :pg, i)))
-                JuMP.@constraint(pm.model, _PMs.var(pm, n, c, :delta_pg, i) >= -(gen["pg"][c] - _PMs.var(pm, n, c, :pg, i)))
-            end
-        end
-    end
-
-    load_weight = Dict(n => Dict(i => get(load, "weight", 1.0) for (i,load) in _PMs.ref(pm, n, :load)) for n in _PMs.nw_ids(pm))
-    M = Dict(n => Dict(c => 10*maximum([load_weight[n][i]*abs(load["pd"][c]) for (i,load) in _PMs.ref(pm, n, :load)]) for c in _PMs.conductor_ids(pm, n)) for n in _PMs.nw_ids(pm))
-
-    JuMP.@objective(pm.model, Min,
-        sum(
-            sum(
-                sum( (                 10*(1 - _PMs.var(pm, n, :z_voltage, i)) for i in keys(nw_ref[:bus]))) +
-                sum( (            M[n][c]*(1 - _PMs.var(pm, n, :z_demand, i))) for i in keys(nw_ref[:load])) +
-                sum( (abs(shunt["gs"][c])*(1 - _PMs.var(pm, n, :z_shunt, i))) for (i,shunt) in nw_ref[:shunt]) +
-                sum( (                     _PMs.var(pm, n, c, :delta_pg, i) for i in keys(nw_ref[:gen])))
-            for c in _PMs.conductor_ids(pm, n))
-        for (n, nw_ref) in _PMs.nws(pm))
-    )
-end
-
-
 "minimum load delta objective (continuous load shed) with storage"
-function objective_mc_min_load_delta_strg(pm::_PMs.AbstractPowerModel)
+function objective_mc_min_load_delta(pm::_PMs.AbstractPowerModel)
     for (n, nw_ref) in _PMs.nws(pm)
         for c in _PMs.conductor_ids(pm, n)
             _PMs.var(pm, n, c)[:delta_pg] = JuMP.@variable(pm.model,
@@ -85,7 +54,7 @@ end
 
 
 "maximum loadability objective (continuous load shed) with storage"
-function objective_mc_max_loadability_strg(pm::_PMs.AbstractPowerModel)
+function objective_mc_max_loadability(pm::_PMs.AbstractPowerModel)
     load_weight = Dict(n => Dict(i => get(load, "weight", 1.0) for (i,load) in _PMs.ref(pm, n, :load)) for n in _PMs.nw_ids(pm))
     M = Dict(n => Dict(c => 10*maximum([load_weight[n][i]*abs(load["pd"][c]) for (i,load) in _PMs.ref(pm, n, :load)]) for c in _PMs.conductor_ids(pm, n)) for n in _PMs.nw_ids(pm))
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -46,95 +46,158 @@ end
 
 
 ""
-function constraint_mc_power_balance_slack(pm::_PMs.AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = _PMs.var(pm, n, c, :vm, i)
-    p_slack = _PMs.var(pm, n, c, :p_slack, i)
-    q_slack = _PMs.var(pm, n, c, :q_slack, i)
-    p = _PMs.var(pm, n, c, :p)
-    q = _PMs.var(pm, n, c, :q)
-    pg = _PMs.var(pm, n, c, :pg)
-    qg = _PMs.var(pm, n, c, :qg)
-    p_dc = _PMs.var(pm, n, c, :p_dc)
-    q_dc = _PMs.var(pm, n, c, :q_dc)
-    pt = _PMs.var(pm, n, c, :pt)
-    qt = _PMs.var(pm, n, c, :qt)
+function constraint_mc_power_balance_slack(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    vm   = _PMs.var(pm, nw, c, :vm, i)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    p_slack = _PMs.var(pm, nw, c, :p_slack, i)
+    q_slack = _PMs.var(pm, nw, c, :q_slack, i)
 
-    _PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2 + p_slack)
-    _PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2 + q_slack)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*vm^2
+        + p_slack
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*vm^2
+        + q_slack
+    )
 end
 
 
 ""
-function constraint_mc_power_balance_shed(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = _PMs.var(pm, nw, c, :vm, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
+function constraint_mc_power_balance_shed(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    vm       = _PMs.var(pm, nw, c, :vm, i)
+    p        = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q        = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg       = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg       = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps       = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs       = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw      = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw      = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt       = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt       = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
     z_demand = _PMs.var(pm, nw, :z_demand)
-    z_shunt = _PMs.var(pm, nw, :z_shunt)
+    z_shunt  = _PMs.var(pm, nw, :z_shunt)
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd*z_demand[n] for (n,pd) in bus_pd) - sum(gs*z_shunt[n] for (n,gs) in bus_gs)*vm^2)
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd*z_demand[n] for (n,qd) in bus_qd) + sum(bs*z_shunt[n] for (n,bs) in bus_bs)*vm^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd*z_demand[n] for (n,pd) in bus_pd)
+        - sum(gs*z_shunt[n] for (n,gs) in bus_gs)*vm^2
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd*z_demand[n] for (n,qd) in bus_qd)
+        + sum(bs*z_shunt[n] for (n,bs) in bus_bs)*vm^2
+    )
 end
 
 
 ""
-function constraint_mc_power_balance(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = _PMs.var(pm, nw, c, :vm, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
+function constraint_mc_power_balance(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    vm   = _PMs.var(pm, nw, c, :vm, i)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*vm^2
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*vm^2
+    )
 end
 
 
-
 ""
-function constraint_mc_power_balance_storage(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = _PMs.var(pm, nw, c, :vm, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    ps = _PMs.var(pm, nw, c, :ps)
-    qs = _PMs.var(pm, nw, c, :qs)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
+function constraint_mc_power_balance_load(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
+    vm   = _PMs.var(pm, nw, c, :vm, i)
+    p    = get(_PMs.var(pm, nw, c),   :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),   :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),  :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),  :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),  :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),  :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c), :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c), :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),  :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),  :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    pd   = get(_PMs.var(pm, nw, c),  :pd, Dict()); _PMs._check_var_keys(pd, bus_loads, "active power", "load")
+    qd   = get(_PMs.var(pm, nw, c),  :qd, Dict()); _PMs._check_var_keys(pd, bus_loads, "reactive power", "load")
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(ps[s] for s in bus_storage) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qs[s] for s in bus_storage) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
-end
-
-
-""
-function constraint_mc_power_balance_load(pm::_PMs.AbstractACPModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_loads, bus_gs, bus_bs)
-    vm = _PMs.var(pm, nw, c, :vm, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    pd = _PMs.var(pm, nw, c, :pd)
-    qd = _PMs.var(pm, nw, c, :qd)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@NLconstraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd[l] for l in bus_loads) - sum(gs for gs in values(bus_gs))*vm^2)
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd[l] for l in bus_loads) + sum(bs for bs in values(bus_bs))*vm^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@NLconstraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd[l] for l in bus_loads)
+        - sum(gs for gs in values(bus_gs))*vm^2
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@NLconstraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd[l] for l in bus_loads)
+        + sum(bs for bs in values(bus_bs))*vm^2
+    )
 end
 
 

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -58,60 +58,122 @@ end
 
 
 ""
-function constraint_mc_power_balance_slack(pm::_PMs.AbstractACRModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vr = _PMs.var(pm, n, c, :vr, i)
-    vi = _PMs.var(pm, n, c, :vi, i)
-    p_slack = _PMs.var(pm, n, c, :p_slack, i)
-    q_slack = _PMs.var(pm, n, c, :q_slack, i)
-    p = _PMs.var(pm, n, c, :p)
-    q = _PMs.var(pm, n, c, :q)
-    pg = _PMs.var(pm, n, c, :pg)
-    qg = _PMs.var(pm, n, c, :qg)
-    p_dc = _PMs.var(pm, n, c, :p_dc)
-    q_dc = _PMs.var(pm, n, c, :q_dc)
-    pt = _PMs.var(pm, n, c, :pt)
-    qt = _PMs.var(pm, n, c, :qt)
+function constraint_mc_power_balance_slack(pm::_PMs.AbstractACRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    vr = _PMs.var(pm, nw, c, :vr, i)
+    vi = _PMs.var(pm, nw, c, :vi, i)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    p_slack = _PMs.var(pm, nw, c, :p_slack, i)
+    q_slack = _PMs.var(pm, nw, c, :q_slack, i)
 
-    _PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2) + p_slack)
-    _PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2) + q_slack)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2)
+        + p_slack
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2)
+        + q_slack
+    )
 end
 
 
 ""
-function constraint_mc_power_balance(pm::_PMs.AbstractACRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_mc_power_balance(pm::_PMs.AbstractACRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vr = _PMs.var(pm, nw, c, :vr, i)
     vi = _PMs.var(pm, nw, c, :vi, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2))
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2))
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2)
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2)
+    )
 end
 
 
 ""
-function constraint_mc_power_balance_load(pm::_PMs.AbstractACRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_loads, bus_gs, bus_bs)
+function constraint_mc_power_balance_load(pm::_PMs.AbstractACRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
     vr = _PMs.var(pm, nw, c, :vr, i)
     vi = _PMs.var(pm, nw, c, :vi, i)
-    p = _PMs.var(pm, nw, c, :p)
-    q = _PMs.var(pm, nw, c, :q)
-    pg = _PMs.var(pm, nw, c, :pg)
-    qg = _PMs.var(pm, nw, c, :qg)
-    pd = _PMs.var(pm, nw, c, :pd)
-    qd = _PMs.var(pm, nw, c, :qd)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    pt = _PMs.var(pm, nw, c, :pt)
-    qt = _PMs.var(pm,  nw, c, :qt)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    pd   = get(_PMs.var(pm, nw, c),  :pd, Dict()); _PMs._check_var_keys(pd, bus_loads, "active power", "load")
+    qd   = get(_PMs.var(pm, nw, c),  :qd, Dict()); _PMs._check_var_keys(pd, bus_loads, "reactive power", "load")
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@NLconstraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd[l] for l in bus_loads) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2))
-    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd[l] for l in bus_loads) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2))
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@NLconstraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd[l] for l in bus_loads)
+        - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2)
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@NLconstraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd[l] for l in bus_loads)
+        + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2)
+    )
 end
 
 

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -6,13 +6,23 @@ end
 
 
 "power balanace constraint with line shunts and transformers, active power only"
-function constraint_mc_power_balance(pm::_PMs.AbstractActivePowerModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    pg   = _PMs.var(pm, nw, c, :pg)
-    p    = _PMs.var(pm, nw, c, :p)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    p_trans = _PMs.var(pm, nw, c, :pt)
+function constraint_mc_power_balance(pm::_PMs.AbstractActivePowerModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
 
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*1.0^2
+    )
     # omit reactive constraint
 end
 
@@ -25,17 +35,4 @@ function constraint_mc_storage_loss(pm::_PMs.AbstractActivePowerModel, n::Int, i
     sd = _PMs.var(pm, n, :sd, i)
 
     JuMP.@NLconstraint(pm.model, sum(ps[c] for c in conductors) + (sd - sc) == standby_loss + sum( r[c]*ps[c]^2 for c in conductors) )
-end
-
-
-"power balance constraint with line shunts, storage, and transformers, active power only"
-function constraint_mc_power_balance_storage(pm::_PMs.AbstractActivePowerModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
-    p    = _PMs.var(pm, nw, c, :p)
-    pg   = _PMs.var(pm, nw, c, :pg)
-    ps   = _PMs.var(pm, nw, c, :ps)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    p_trans = _PMs.var(pm, nw, c, :pt)
-
-    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(ps[s] for s in bus_storage) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
-    # omit reactive constraint
 end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -1,19 +1,41 @@
 ""
-function constraint_mc_power_balance_slack(pm::_PMs.AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    w    = _PMs.var(pm, n, c, :w, i)
-    p_slack = _PMs.var(pm, n, c, :p_slack, i)
-    q_slack = _PMs.var(pm, n, c, :q_slack, i)
-    pg   = _PMs.var(pm, n, c, :pg)
-    qg   = _PMs.var(pm, n, c, :qg)
-    p    = _PMs.var(pm, n, c, :p)
-    q    = _PMs.var(pm, n, c, :q)
-    p_dc = _PMs.var(pm, n, c, :p_dc)
-    q_dc = _PMs.var(pm, n, c, :q_dc)
-    pt = _PMs.var(pm, n, c, :pt)
-    qt = _PMs.var(pm, n, c, :qt)
+function constraint_mc_power_balance_slack(pm::_PMs.AbstractWModels, nw::Int, c::Int, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    w    = _PMs.var(pm, nw, c, :w, i)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    p_slack = _PMs.var(pm, nw, c, :p_slack, i)
+    q_slack = _PMs.var(pm, nw, c, :q_slack, i)
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w + p_slack)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w + q_slack)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*w
+        + p_slack
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*w
+        + q_slack
+    )
 end
 
 
@@ -90,21 +112,41 @@ end
 
 
 "KCL for load shed problem with transformers (AbstractWForms)"
-function constraint_mc_power_balance_shed(pm::_PMs.AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    w    = _PMs.var(pm, n, c, :w, i)
-    pg   = _PMs.var(pm, n, c, :pg)
-    qg   = _PMs.var(pm, n, c, :qg)
-    p    = _PMs.var(pm, n, c, :p)
-    q    = _PMs.var(pm, n, c, :q)
-    p_dc = _PMs.var(pm, n, c, :p_dc)
-    q_dc = _PMs.var(pm, n, c, :q_dc)
-    pt = _PMs.var(pm, n, c, :pt)
-    qt = _PMs.var(pm, n, c, :qt)
-    z_demand = _PMs.var(pm, n, :z_demand)
-    z_shunt = _PMs.var(pm, n, :z_shunt)
+function constraint_mc_power_balance_shed(pm::_PMs.AbstractWModels, nw::Int, c::Int, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    w    = _PMs.var(pm, nw, c, :w, i)
+    p        = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q        = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg       = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg       = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps       = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs       = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw      = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw      = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt       = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt       = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+    z_demand = _PMs.var(pm, nw, :z_demand)
+    z_shunt  = _PMs.var(pm, nw, :z_shunt)
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(pt[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd*z_demand[i] for (i,pd) in bus_pd) - sum(gs*1.0^2*z_shunt[i] for (i,gs) in bus_gs)*w)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qt[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd*z_demand[i] for (i,qd) in bus_qd) + sum(bs*1.0^2*z_shunt[i] for (i,bs) in bus_bs)*w)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd*z_demand[n] for (n,pd) in bus_pd)
+        - sum(gs*1.0^2*z_shunt[n] for (n,gs) in bus_gs)*w
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd*z_demand[n] for (n,qd) in bus_qd)
+        + sum(bs*1.0^2*z_shunt[n] for (n,bs) in bus_bs)*w
+    )
 end
 
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -75,17 +75,38 @@ end
 
 
 "power balance constraint with line shunts and transformers for relaxed WR forms"
-function constraint_mc_power_balance(pm::_PMs.AbstractWRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_mc_power_balance(pm::_PMs.AbstractWRModel, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = _PMs.var(pm, nw, c, :w, i)
-    pg   = _PMs.var(pm, nw, c, :pg)
-    qg   = _PMs.var(pm, nw, c, :qg)
-    p    = _PMs.var(pm, nw, c, :p)
-    q    = _PMs.var(pm, nw, c, :q)
-    p_dc = _PMs.var(pm, nw, c, :p_dc)
-    q_dc = _PMs.var(pm, nw, c, :q_dc)
-    p_trans = _PMs.var(pm, nw, c, :pt)
-    q_trans = _PMs.var(pm,  nw, c, :qt)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w)
+
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*w
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*w
+    )
 end

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -268,16 +268,6 @@ end
 
 
 """
-    _get_prop_name(ctype, i)
-
-Returns the `i`th property name for a given component type `ctype`.
-"""
-function _get_prop_name(ctype::AbstractString, i::Int)::String
-    return _get_prop_name(ctype)[i]
-end
-
-
-"""
     _parse_matrix(dtype, data)
 
 Parses a OpenDSS style triangular matrix string `data` into a two dimensional

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -1047,10 +1047,6 @@ function _get_dtypes(comp::AbstractString)::Dict
 end
 
 
-""
-_get_dtypes(comp::String, key::String)::Type = _get_dtypes(comp)[key]
-
-
 "list of constructor functions for easy access"
 const _constructors = Dict{String,Any}("line" => _create_line,
                                        "load" => _create_load,

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -30,33 +30,6 @@ function _get_linecode(dss_data::Dict, id::AbstractString)
 end
 
 
-"creates a starbus from a 3-winding transformer"
-function _create_starbus(pmd_data::Dict, transformer::Dict)::Dict
-    starbus = Dict{String,Any}()
-
-    base = convert(Int, 10^ceil(log10(abs(_PMs.find_max_bus_id(pmd_data)))))
-    name, nodes = _parse_busname(transformer["buses"][1])
-    nconductors = pmd_data["conductors"]
-    starbus_id = _find_bus(name, pmd_data) + base
-
-    starbus["bus_i"] = starbus_id
-    starbus["base_kv"] = 1.0
-    starbus["vmin"] = _PMs.MultiConductorVector(_parse_array(0.9, nodes, nconductors, 0.9))
-    starbus["vmax"] = _PMs.MultiConductorVector(_parse_array(1.1, nodes, nconductors, 1.1))
-    starbus["name"] = "$(transformer["name"]) starbus"
-    starbus["vm"] = _PMs.MultiConductorVector(_parse_array(1.0, nodes, nconductors))
-    starbus["va"] = _PMs.MultiConductorVector(_parse_array(0.0, nodes, nconductors))
-    starbus["bus_type"] = 1
-    starbus["index"] = starbus_id
-
-    nodes = .+([_parse_busname(transformer["buses"][n])[2] for n in length(transformer["buses"])]...)
-    starbus["active_phases"] = [n for n in 1:nconductors if nodes[n] > 0]
-    starbus["source_id"] = "transformer.$(transformer["name"])"
-
-    return starbus
-end
-
-
 """
     _discover_buses(dss_data)
 
@@ -131,7 +104,6 @@ function _dss2pmd_bus!(pmd_data::Dict, dss_data::Dict, import_all::Bool=false, v
     end
 
     # create virtual sourcebus
-
     circuit = _create_vsource(get(dss_data["circuit"][1], "bus1", "sourcebus"), dss_data["circuit"][1]["name"]; _to_sym_keys(dss_data["circuit"][1])...)
 
     busDict = Dict{String,Any}()

--- a/src/prob/debug.jl
+++ b/src/prob/debug.jl
@@ -35,7 +35,6 @@ function post_mc_opf_pbs(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -60,10 +59,6 @@ function post_mc_opf_pbs(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
-    end
-
     objective_min_bus_power_slack(pm)
 end
 
@@ -81,7 +76,6 @@ function post_mc_pf_pbs(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, bounded=false, cnd=c)
-        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -115,20 +109,6 @@ function post_mc_pf_pbs(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
-    end
-
-    for (i,dcline) in _PMs.ref(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
-
-        f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
-        if f_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
-        end
-
-        t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
-        if t_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
-        end
     end
 
     objective_min_bus_power_slack(pm)

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -1,4 +1,4 @@
-"Run load shedding problem"
+"Run load shedding problem with storage"
 function run_mc_mld(data::Dict{String,Any}, model_type, solver; kwargs...)
     return _PMs.run_model(data, model_type, solver, post_mc_mld; multiconductor=true, ref_extensions=[ref_add_arcs_trans!], solution_builder=solution_mld!, kwargs...)
 end
@@ -7,18 +7,6 @@ end
 ""
 function run_mc_mld(file::String, model_type, solver; kwargs...)
     return run_mc_mld(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
-end
-
-
-"Run load shedding problem with storage"
-function run_mc_mld_strg(data::Dict{String,Any}, model_type, solver; kwargs...)
-    return _PMs.run_model(data, model_type, solver, post_mc_mld_strg; multiconductor=true, ref_extensions=[ref_add_arcs_trans!], solution_builder=solution_mld!, kwargs...)
-end
-
-
-""
-function run_mc_mld_strg(file::String, model_type, solver; kwargs...)
-    return run_mc_mld_strg(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
 end
 
 
@@ -49,65 +37,8 @@ function run_mc_mld_uc(file::String, model_type, solver; kwargs...)
 end
 
 
-"Standard load shedding problem"
+"Load shedding problem"
 function post_mc_mld(pm::_PMs.AbstractPowerModel)
-    variable_mc_indicator_bus_voltage(pm; relax=true)
-    variable_mc_bus_voltage_on_off(pm)
-
-    variable_mc_branch_flow(pm)
-    variable_mc_transformer_flow(pm)
-
-    variable_mc_indicator_generation(pm; relax=true)
-
-    variable_mc_indicator_demand(pm; relax=true)
-    variable_mc_indicator_shunt(pm; relax=true)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation_on_off(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
-    end
-
-    constraint_mc_model_voltage(pm)
-
-    for i in _PMs.ids(pm, :ref_buses)
-        constraint_mc_theta_ref(pm, i)
-    end
-
-    constraint_mc_bus_voltage_on_off(pm)
-
-    for i in _PMs.ids(pm, :gen)
-        _PMs.constraint_generation_on_off(pm, i)
-    end
-
-    for i in _PMs.ids(pm, :bus)
-        constraint_mc_power_balance_shed(pm, i)
-    end
-
-    for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
-        constraint_mc_ohms_yt_from(pm, i)
-        constraint_mc_ohms_yt_to(pm, i)
-
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
-    end
-
-    for i in _PMs.ids(pm, :transformer)
-        constraint_mc_trans(pm, i)
-    end
-
-    objective_mc_min_load_delta(pm)
-end
-
-
-"Load shedding problem with storage"
-function post_mc_mld_strg(pm::_PMs.AbstractPowerModel)
     variable_mc_indicator_bus_voltage(pm; relax=true)
     variable_mc_bus_voltage_on_off(pm)
 
@@ -125,7 +56,6 @@ function post_mc_mld_strg(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation_on_off(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -165,15 +95,11 @@ function post_mc_mld_strg(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
-    end
-
     for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
 
-    objective_mc_min_load_delta_strg(pm)
+    objective_mc_min_load_delta(pm)
 end
 
 
@@ -193,7 +119,6 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation_on_off(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_current(pm)
@@ -224,10 +149,6 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
-    end
-
     for i in _PMs.ids(pm, :transformer)
         constraint_mc_trans(pm, i)
     end
@@ -246,12 +167,15 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
 
     variable_mc_indicator_generation(pm; relax=false)
 
+    variable_mc_storage(pm)
+    variable_mc_indicator_storage(pm; relax=false)
+    variable_mc_on_off_storage(pm)
+
     variable_mc_indicator_demand(pm; relax=false)
     variable_mc_indicator_shunt(pm; relax=false)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation_on_off(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -270,6 +194,15 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
         constraint_mc_power_balance_shed(pm, i)
     end
 
+    for i in _PMs.ids(pm, :storage)
+        _PMs.constraint_storage_state(pm, i)
+        _PMs.constraint_storage_complementarity_nl(pm, i)
+        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
+        for c in _PMs.conductor_ids(pm)
+            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
+        end
+    end
+
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
@@ -280,10 +213,6 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
             _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
             _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -21,10 +21,10 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
     variable_mc_transformer_flow(pm)
+    variable_mc_storage(pm)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -37,6 +37,15 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
         constraint_mc_power_balance(pm, i)
     end
 
+    for i in _PMs.ids(pm, :storage)
+        _PMs.constraint_storage_state(pm, i)
+        _PMs.constraint_storage_complementarity_nl(pm, i)
+        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
+        for c in _PMs.conductor_ids(pm)
+            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
+        end
+    end
+
     for i in _PMs.ids(pm, :branch)
         constraint_mc_voltage_angle_difference(pm, i)
         constraint_mc_ohms_yt_from(pm, i)
@@ -46,10 +55,6 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
             _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
             _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_bctr.jl
+++ b/src/prob/opf_bctr.jl
@@ -18,7 +18,6 @@ function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -45,10 +44,6 @@ function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
             _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
             _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -1,6 +1,6 @@
 ""
 function run_mc_opf_bf(data::Dict{String,Any}, model_type, solver; kwargs...)
-    return _PMs.run_model(data, model_type, solver, post_mc_opf_bf; solution_builder=solution_tp!, multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_type, solver, post_mc_opf_bf; solution_builder=solution_tp!, ref_extensions=[ref_add_arcs_trans!], multiconductor=true, kwargs...)
 end
 
 
@@ -19,7 +19,6 @@ function post_mc_opf_bf(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     # Constraints
@@ -44,8 +43,8 @@ function post_mc_opf_bf(pm::_PMs.AbstractPowerModel)
         end
     end
 
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :transformer)
+        constraint_mc_trans(pm, i)
     end
 
     # Objective

--- a/src/prob/opf_lm.jl
+++ b/src/prob/opf_lm.jl
@@ -29,7 +29,6 @@ function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -56,10 +55,6 @@ function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
             _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
             _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -23,7 +23,6 @@ function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
     end
     variable_mc_transformer_flow(pm)
     variable_mc_oltc_tap(pm)
@@ -47,10 +46,6 @@ function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
             _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
             _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -30,7 +30,6 @@ function post_mc_pf(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, bounded=false, cnd=c)
-        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -64,21 +63,6 @@ function post_mc_pf(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
-    end
-
-    for (i,dcline) in _PMs.ref(pm, :dcline), c in _PMs.conductor_ids(pm)
-
-        _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
-
-        f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
-        if f_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
-        end
-
-        t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
-        if t_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
-        end
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/pf_lm.jl
+++ b/src/prob/pf_lm.jl
@@ -31,7 +31,6 @@ function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
 
     for c in _PMs.conductor_ids(pm)
         _PMs.variable_generation(pm, bounded=false, cnd=c)
-        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
     constraint_mc_model_voltage(pm)
@@ -70,20 +69,6 @@ function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
-    end
-
-    for (i,dcline) in _PMs.ref(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
-
-        f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
-        if f_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
-        end
-
-        t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
-        if t_bus["bus_type"] == 1
-            _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
-        end
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -4,84 +4,15 @@
 # such as storage devices
 #
 ######
-
-"opf with storage"
-function run_mc_strg_opf(data::Dict{String,Any}, model_type, solver; kwargs...)
-    return _PMs.run_model(data, model_type, solver, post_mc_strg_opf; multiconductor=true, ref_extensions=[ref_add_arcs_trans!], kwargs...)
-end
-
-
-""
-function run_mc_strg_opf(file::String, model_type, solver; kwargs...)
-    return run_mc_strg_opf(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
-end
-
-
-""
-function post_mc_strg_opf(pm::_PMs.AbstractPowerModel)
-    variable_mc_voltage(pm)
-    variable_mc_branch_flow(pm)
-    variable_mc_transformer_flow(pm)
-    variable_mc_storage(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-        _PMs.variable_dcline_flow(pm, cnd=c)
-    end
-
-    constraint_mc_model_voltage(pm)
-
-    for i in _PMs.ids(pm, :ref_buses)
-        constraint_mc_theta_ref(pm, i)
-    end
-
-    for i in _PMs.ids(pm, :bus)
-        constraint_mc_power_balance_storage(pm, i)
-    end
-
-    for i in _PMs.ids(pm, :storage)
-        _PMs.constraint_storage_state(pm, i)
-        _PMs.constraint_storage_complementarity_nl(pm, i)
-        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
-        end
-    end
-
-    for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
-        constraint_mc_ohms_yt_from(pm, i)
-        constraint_mc_ohms_yt_to(pm, i)
-
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
-    end
-
-    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_dcline(pm, i, cnd=c)
-    end
-
-    for i in _PMs.ids(pm, :transformer)
-        constraint_mc_trans(pm, i)
-    end
-
-    _PMs.objective_min_fuel_cost(pm)
-end
-
-
-
-
 "multi-network opf with storage"
-function run_mn_mc_strg_opf(data::Dict{String,Any}, model_type, solver; kwargs...)
+function run_mn_mc_opf(data::Dict{String,Any}, model_type, solver; kwargs...)
     return _PMs.run_model(data, model_type, solver, post_mn_mc_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
 end
 
 
 ""
-function run_mn_mc_strg_opf(file::String, model_type, solver; kwargs...)
-    return run_mn_mc_strg_opf(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
+function run_mn_mc_opf(file::String, model_type, solver; kwargs...)
+    return run_mn_mc_opf(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
 end
 
 
@@ -125,10 +56,6 @@ function post_mn_mc_strg_opf(pm::_PMs.AbstractPowerModel)
                 _PMs.constraint_thermal_limit_from(pm, i, cnd=c, nw=n)
                 _PMs.constraint_thermal_limit_to(pm, i, cnd=c, nw=n)
             end
-        end
-
-        for i in _PMs.ids(pm, :dcline, nw=n), c in _PMs.conductor_ids(pm, nw=n)
-            _PMs.constraint_dcline(pm, i, cnd=c, nw=n)
         end
     end
 

--- a/test/mld.jl
+++ b/test/mld.jl
@@ -18,7 +18,7 @@
         result = run_mc_mld(mp_data, PMs.ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
-        @test isapprox(result["objective"], 0.3553; atol=1e-4)
+        @test isapprox(result["objective"], 0.3553; atol=1e-2)
 
         @test isapprox(result["solution"]["load"]["1"]["status"], 1.000; atol=1e-3)
     end

--- a/test/mld.jl
+++ b/test/mld.jl
@@ -15,7 +15,7 @@
 
     @testset "5-bus storage acp mld" begin
         mp_data = PMs.parse_file("$(pms_path)/test/data/matpower/case5_strg.m"); PMD.make_multiconductor!(mp_data, 3)
-        result = run_mc_mld_strg(mp_data, PMs.ACPPowerModel, ipopt_solver)  # why higher tol required?
+        result = run_mc_mld(mp_data, PMs.ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.3553; atol=1e-4)
@@ -35,7 +35,7 @@
 
     @testset "5-bus storage nfa mld" begin
         mp_data = PMs.parse_file("$(pms_path)/test/data/matpower/case5_strg.m"); PMD.make_multiconductor!(mp_data, 3)
-        result = run_mc_mld_strg(mp_data, PMs.NFAPowerModel, ipopt_solver)
+        result = run_mc_mld(mp_data, PMs.NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.1557; atol=1e-4)

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -6,7 +6,7 @@
         PMD.make_multiconductor!(mp_data, 3)
         mn_mp_data = PowerModels.replicate(mp_data, 5)
 
-        result = PMD.run_mn_mc_strg_opf(mn_mp_data, PowerModels.ACPPowerModel, ipopt_solver)
+        result = PMD.run_mn_mc_opf(mn_mp_data, PowerModels.ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 2.64596e5; atol = 1e2)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -2,18 +2,6 @@
 
 @testset "test opf" begin
     @testset "test matpower opf" begin
-        @testset "3-bus matlab acp opf" begin
-            mp_data = PMs.parse_file("$(pms_path)/test/data/matpower/case3.m")
-            PMD.make_multiconductor!(mp_data, 3)
-            result = run_mc_opf(mp_data, PMs.ACPPowerModel, ipopt_solver)
-
-            @test result["termination_status"] == PMs.LOCALLY_SOLVED
-            @test isapprox(result["objective"], 47267.9; atol=1e-1)
-
-            @test all(isapprox(result["solution"]["gen"]["1"]["pg"][c], 1.58067; atol=1e-3) for c in 1:mp_data["conductors"])
-            @test all(isapprox(result["solution"]["bus"]["2"]["va"][c], PMD._wrap_to_pi(0.12669+2*pi/mp_data["conductors"]*(1-c)); atol=1e-3) for c in 1:mp_data["conductors"])
-        end
-
         @testset "5-bus matpower acp opf" begin
             mp_data = PMs.parse_file("../test/data/matpower/case5.m")
             PMD.make_multiconductor!(mp_data, 3)

--- a/test/opf_bf.jl
+++ b/test/opf_bf.jl
@@ -2,16 +2,6 @@
 
 @testset "test distflow formulations" begin
     @testset "test linearised distflow opf_bf" begin
-        @testset "3-bus lplinubf opf_bf" begin
-            mp_data = PowerModels.parse_file("$(pms_path)/test/data/matpower/case3.m")
-            PMD.make_multiconductor!(mp_data, 3)
-            result = run_mc_opf_bf(mp_data, LPLinUBFPowerModel, ipopt_solver)
-
-            @test result["termination_status"] == PMs.LOCALLY_SOLVED
-            @test isapprox(result["objective"], 45500.2 ; atol = 1e0)
-            @test isapprox(result["solution"]["bus"]["3"]["vm"].values, 0.992977*[1,1,1]; atol = 1e-3)
-        end
-
         @testset "5-bus lplinubf opf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             PMD.make_multiconductor!(mp_data, 3)
@@ -60,15 +50,6 @@
     end
 
     @testset "test linearised distflow opf_bf in diagonal matrix form" begin
-        @testset "3-bus lpdiagubf opf_bf" begin
-            mp_data = PowerModels.parse_file("$(pms_path)/test/data/matpower/case3.m")
-            PMD.make_multiconductor!(mp_data, 3)
-            result = run_mc_opf_bf(mp_data, LPdiagUBFPowerModel, ipopt_solver)
-
-            @test result["termination_status"] == PMs.LOCALLY_SOLVED
-            @test isapprox(result["objective"], 45500.2 ; atol = 1e0)
-        end
-
         @testset "5-bus lpdiagubf opf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             PMD.make_multiconductor!(mp_data, 3)
@@ -98,15 +79,6 @@
     end
 
     @testset "test linearised distflow opf_bf in full matrix form" begin
-        @testset "3-bus lpfullubf opf_bf" begin
-            mp_data = PowerModels.parse_file("$(pms_path)/test/data/matpower/case3.m")
-            PMD.make_multiconductor!(mp_data, 3)
-            result = run_mc_opf_bf(mp_data, LPfullUBFPowerModel, ipopt_solver)
-
-            @test result["termination_status"] == PMs.LOCALLY_SOLVED
-            @test isapprox(result["objective"], 45500.2 ; atol = 1e0)
-        end
-
         @testset "5-bus lpfullubf opf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             PMD.make_multiconductor!(mp_data, 3)

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,11 +1,11 @@
-@info "running storage optimal power flow (test) tests"
+@info "running storage optimal power flow tests"
 
 @testset "test storage opf" begin
     @testset "5-bus storage acp opf_strg" begin
         mp_data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         PMD.make_multiconductor!(mp_data, 3)
 
-        result = PMD.run_mc_strg_opf(mp_data, PowerModels.ACPPowerModel, ipopt_solver)
+        result = PMD.run_mc_opf(mp_data, PowerModels.ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 52299.2; atol = 1e0)
@@ -22,7 +22,7 @@
         mp_data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         PMD.make_multiconductor!(mp_data, 3)
 
-        result = PMD.run_mc_strg_opf(mp_data, PowerModels.DCPPowerModel, ipopt_solver)
+        result = PMD.run_mc_opf(mp_data, PowerModels.DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 52059.6; atol = 1e0)
@@ -40,7 +40,7 @@
         mp_data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         PMD.make_multiconductor!(mp_data, 3)
 
-        result = PMD.run_mc_strg_opf(mp_data, PowerModels.NFAPowerModel, ipopt_solver)
+        result = PMD.run_mc_opf(mp_data, PowerModels.NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 43169.9; atol = 1e0)


### PR DESCRIPTION
Changes to PowerModels v0.13 style of `constraint_power_balance` to make it more generic, including all types of components, and therefore making it more robust to various network compositions.

Removes DC-lines (no such network components yet defined for distribution networks in this package).

Merges storage into main opf and mld problems.

Removes some unused functions.

Removed 4 tests using 3-bus matpower file, due to precense of dclines.

Updates changelog.