### PR TITLE
REF: Remove loops over conductors from prob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Refactored problem definitions to remove any explicit loops over conductors (#181)
 - Added data format documentation (#180)
 - Moved storage to main MLD and OPF problems (#179)
 - Refactor to remove dcline variables and constraints (#179)

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -50,8 +50,8 @@ function ref_add_arcs_trans!(pm::_PMs.AbstractPowerModel)
             _PMs.ref(pm, nw)[:transformer] = Dict{Int, Any}()
         end
         # dirty fix add arcs_from/to_trans and bus_arcs_trans
-        pm.ref[:nw][nw][:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in _PMs.ref(pm, :transformer)]
-        pm.ref[:nw][nw][:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in _PMs.ref(pm, :transformer)]
+        pm.ref[:nw][nw][:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in _PMs.ref(pm, nw, :transformer)]
+        pm.ref[:nw][nw][:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in _PMs.ref(pm, nw, :transformer)]
         pm.ref[:nw][nw][:arcs_trans] = [pm.ref[:nw][nw][:arcs_from_trans]..., pm.ref[:nw][nw][:arcs_to_trans]...]
         pm.ref[:nw][nw][:bus_arcs_trans] = Dict{Int64, Array{Any, 1}}()
         for i in _PMs.ids(pm, :bus)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -150,6 +150,43 @@ function constraint_mc_power_balance_shed(pm::_PMs.AbstractWModels, nw::Int, c::
 end
 
 
+""
+function constraint_mc_power_balance(pm::_PMs.AbstractWModels, nw::Int, c::Int, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    w    = _PMs.var(pm, nw, c, :w, i)
+    p    = get(_PMs.var(pm, nw, c),    :p, Dict()); _PMs._check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(_PMs.var(pm, nw, c),    :q, Dict()); _PMs._check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(_PMs.var(pm, nw, c),   :pg, Dict()); _PMs._check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(_PMs.var(pm, nw, c),   :qg, Dict()); _PMs._check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(_PMs.var(pm, nw, c),   :ps, Dict()); _PMs._check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(_PMs.var(pm, nw, c),   :qs, Dict()); _PMs._check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(_PMs.var(pm, nw, c),  :psw, Dict()); _PMs._check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(_PMs.var(pm, nw, c),  :qsw, Dict()); _PMs._check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    pt   = get(_PMs.var(pm, nw, c),   :pt, Dict()); _PMs._check_var_keys(pt, bus_arcs_trans, "active power", "transformer")
+    qt   = get(_PMs.var(pm, nw, c),   :qt, Dict()); _PMs._check_var_keys(qt, bus_arcs_trans, "reactive power", "transformer")
+
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(pt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*w
+    )
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(qt[a_trans] for a_trans in bus_arcs_trans)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*w
+    )
+end
+
+
 "delegate back to PowerModels"
 function constraint_mc_ohms_yt_from(pm::_PMs.AbstractWModels, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     _PMs.constraint_mc_ohms_yt_from(pm, n, c, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)

--- a/src/prob/debug.jl
+++ b/src/prob/debug.jl
@@ -1,41 +1,39 @@
 # These problem formulations are used to debug Distribution datasets
 # that do not converge using the standard formulations
-""
+"OPF problem with slack power at every bus"
 function run_mc_opf_pbs(data::Dict{String,Any}, model_type, solver; kwargs...)
     return _PMs.run_model(data, model_type, solver, post_mc_opf_pbs; multiconductor=true, ref_extensions=[ref_add_arcs_trans!], solution_builder=solution_pbs!, kwargs...)
 end
 
 
-""
+"OPF problem with slack power at every bus"
 function run_mc_opf_pbs(file::String, model_type, solver; kwargs...)
     return run_mc_opf_pbs(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
 end
 
 
-""
+"PF problem with slack power at every bus"
 function run_mc_pf_pbs(data::Dict{String,Any}, model_type, solver; kwargs...)
     return _PMs.run_model(data, model_type, solver, post_mc_pf_pbs; multiconductor=true, ref_extensions=[ref_add_arcs_trans!], solution_builder=solution_pbs!, kwargs...)
 end
 
 
-""
+"PF problem with slack power at every bus"
 function run_mc_pf_pbs(file::String, model_type, solver; kwargs...)
     return run_mc_pf_pbs(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
 end
 
 
-""
+"OPF problem with slack power at every bus"
 function post_mc_opf_pbs(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
 
     variable_mc_branch_flow(pm)
     variable_mc_transformer_flow(pm)
 
-    variable_mc_bus_power_slack(pm)
+    variable_mc_generation(pm)
 
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
+    variable_mc_bus_power_slack(pm)
 
     constraint_mc_model_voltage(pm)
 
@@ -51,57 +49,47 @@ function post_mc_opf_pbs(pm::_PMs.AbstractPowerModel)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        constraint_mc_voltage_angle_difference(pm, i)
 
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     objective_min_bus_power_slack(pm)
 end
 
 
-
-
-""
+"PF problem with slack power at every bus"
 function post_mc_pf_pbs(pm::_PMs.AbstractPowerModel)
-    variable_mc_voltage(pm, bounded=false)
+    variable_mc_voltage(pm; bounded=false)
 
-    variable_mc_branch_flow(pm, bounded=false)
-    variable_mc_transformer_flow(pm, bounded=false)
+    variable_mc_branch_flow(pm; bounded=false)
+    variable_mc_transformer_flow(pm; bounded=false)
+
+    variable_mc_generation(pm; bounded=false)
 
     variable_mc_bus_power_slack(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, bounded=false, cnd=c)
-    end
 
     constraint_mc_model_voltage(pm)
 
     for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_mc_theta_ref(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            @assert bus["bus_type"] == 3
-            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-        end
+        @assert bus["bus_type"] == 3
+        constraint_mc_voltage_magnitude_setpoint(pm, i)
     end
 
     for (i,bus) in _PMs.ref(pm, :bus)
         constraint_mc_power_balance_slack(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            # PV Bus Constraints
-            if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
-                # this assumes inactive generators are filtered out of bus_gens
-                @assert bus["bus_type"] == 2
+        # PV Bus Constraints
+        if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
+            # this assumes inactive generators are filtered out of bus_gens
+            @assert bus["bus_type"] == 2
 
-                _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-                for j in _PMs.ref(pm, :bus_gens, i)
-                    _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
-                end
+            constraint_mc_voltage_magnitude_setpoint(pm, i)
+            for j in _PMs.ref(pm, :bus_gens, i)
+                constraint_mc_active_gen_setpoint(pm, j)
             end
         end
     end

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -37,7 +37,7 @@ function run_mc_mld_uc(file::String, model_type, solver; kwargs...)
 end
 
 
-"Load shedding problem"
+"Load shedding problem including storage"
 function post_mc_mld(pm::_PMs.AbstractPowerModel)
     variable_mc_indicator_bus_voltage(pm; relax=true)
     variable_mc_bus_voltage_on_off(pm)
@@ -46,6 +46,7 @@ function post_mc_mld(pm::_PMs.AbstractPowerModel)
     variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=true)
+    variable_mc_generation_on_off(pm)
 
     variable_mc_storage(pm)
     variable_mc_indicator_storage(pm; relax=true)
@@ -53,10 +54,6 @@ function post_mc_mld(pm::_PMs.AbstractPowerModel)
 
     variable_mc_indicator_demand(pm; relax=true)
     variable_mc_indicator_shunt(pm; relax=true)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation_on_off(pm, cnd=c)
-    end
 
     constraint_mc_model_voltage(pm)
 
@@ -77,22 +74,18 @@ function post_mc_mld(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :storage)
         _PMs.constraint_storage_state(pm, i)
         _PMs.constraint_storage_complementarity_nl(pm, i)
-        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
-        end
+        constraint_mc_storage_loss(pm, i)
+        constraint_mc_storage_thermal_limit(pm, i)
     end
 
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        constraint_mc_voltage_angle_difference(pm, i)
 
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)
@@ -113,13 +106,10 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
     variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=true)
+    variable_mc_generation_on_off(pm)
 
     variable_mc_indicator_demand(pm; relax=true)
     variable_mc_indicator_shunt(pm; relax=true)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation_on_off(pm, cnd=c)
-    end
 
     constraint_mc_model_current(pm)
 
@@ -141,12 +131,10 @@ function post_mc_mld_bf(pm::_PMs.AbstractPowerModel)
         constraint_mc_flow_losses(pm, i)
         constraint_mc_model_voltage_magnitude_difference(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        constraint_mc_voltage_angle_difference(pm, i)
 
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)
@@ -166,6 +154,7 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
     variable_mc_transformer_flow(pm)
 
     variable_mc_indicator_generation(pm; relax=false)
+    variable_mc_generation_on_off(pm)
 
     variable_mc_storage(pm)
     variable_mc_indicator_storage(pm; relax=false)
@@ -173,10 +162,6 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
 
     variable_mc_indicator_demand(pm; relax=false)
     variable_mc_indicator_shunt(pm; relax=false)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation_on_off(pm, cnd=c)
-    end
 
     constraint_mc_model_voltage(pm)
 
@@ -197,22 +182,18 @@ function post_mc_mld_uc(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :storage)
         _PMs.constraint_storage_state(pm, i)
         _PMs.constraint_storage_complementarity_nl(pm, i)
-        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
-        end
+        constraint_mc_storage_loss(pm, i)
+        constraint_mc_storage_thermal_limit(pm, i)
     end
 
     for i in _PMs.ids(pm, :branch)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        constraint_mc_voltage_angle_difference(pm, i)
 
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -21,11 +21,8 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
     variable_mc_transformer_flow(pm)
+    variable_mc_generation(pm)
     variable_mc_storage(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
 
     constraint_mc_model_voltage(pm)
 
@@ -40,21 +37,18 @@ function post_mc_opf(pm::_PMs.AbstractPowerModel)
     for i in _PMs.ids(pm, :storage)
         _PMs.constraint_storage_state(pm, i)
         _PMs.constraint_storage_complementarity_nl(pm, i)
-        _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm))
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
-        end
+        constraint_mc_storage_loss(pm, i)
+        constraint_mc_storage_thermal_limit(pm, i)
     end
 
     for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_bctr.jl
+++ b/src/prob/opf_bctr.jl
@@ -15,10 +15,7 @@ function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
     variable_mc_transformer_flow(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
+    variable_mc_generation(pm)
 
     constraint_mc_model_voltage(pm)
 
@@ -31,19 +28,18 @@ function post_mc_opf_bctr(pm::_PMs.AbstractPowerModel)
         constraint_mc_voltage_balance(pm, i)
 
         for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_power_balance(pm, i, cnd=c)
+            _PMs.constraint_power_balance(pm, i; cnd=c)  # TODO: Create appropriate constraint variations for constraint_mc_power_balance
         end
     end
 
     for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -16,10 +16,8 @@ function post_mc_opf_bf(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_current(pm)
     variable_mc_branch_flow(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
+    variable_mc_transformer_flow(pm)
+    variable_mc_generation(pm)
 
     # Constraints
     constraint_mc_model_current(pm)
@@ -28,19 +26,18 @@ function post_mc_opf_bf(pm::_PMs.AbstractPowerModel)
         constraint_mc_theta_ref(pm, i)
     end
 
-    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_power_balance(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus)
+        constraint_mc_power_balance(pm, i)
     end
 
     for i in _PMs.ids(pm, :branch)
         constraint_mc_flow_losses(pm, i)
         constraint_mc_model_voltage_magnitude_difference(pm, i)
+
         constraint_mc_voltage_angle_difference(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_lm.jl
+++ b/src/prob/opf_lm.jl
@@ -25,11 +25,8 @@ function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
     variable_mc_transformer_flow(pm)
+    variable_mc_generation(pm)
     variable_mc_load(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
 
     constraint_mc_model_voltage(pm)
 
@@ -47,14 +44,13 @@ function post_mc_opf_lm(pm::_PMs.AbstractPowerModel)
     end
 
     for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -20,10 +20,7 @@ end
 function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
     variable_mc_voltage(pm)
     variable_mc_branch_flow(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, cnd=c)
-    end
+    variable_mc_generation(pm)
     variable_mc_transformer_flow(pm)
     variable_mc_oltc_tap(pm)
 
@@ -38,14 +35,13 @@ function post_mc_opf_oltc(pm::_PMs.AbstractPowerModel)
     end
 
     for i in _PMs.ids(pm, :branch)
-        constraint_mc_voltage_angle_difference(pm, i)
         constraint_mc_ohms_yt_from(pm, i)
         constraint_mc_ohms_yt_to(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     for i in _PMs.ids(pm, :transformer)

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -16,13 +16,10 @@ end
 ""
 function post_mc_pf_bf(pm::_PMs.AbstractPowerModel)
     # Variables
-    variable_mc_voltage(pm, bounded=false)
+    variable_mc_voltage(pm; bounded=false)
     variable_mc_branch_current(pm)
     variable_mc_branch_flow(pm)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, bounded=false, cnd=c)
-    end
+    variable_mc_generation(pm; bounded=false)
 
     # Constraints
     constraint_mc_model_current(pm)
@@ -30,38 +27,32 @@ function post_mc_pf_bf(pm::_PMs.AbstractPowerModel)
     for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_mc_theta_ref(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            @assert bus["bus_type"] == 3
-            # _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c) #TODO add back
-        end
+        @assert bus["bus_type"] == 3
+        # constraint_mc_voltage_magnitude_setpoint(pm, i) #TODO add back
     end
 
-    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
-        _PMs.constraint_power_balance(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus)
+        constraint_mc_power_balance(pm, i)
 
         # PV Bus Constraints
         if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
             # this assumes inactive generators are filtered out of bus_gens
             @assert bus["bus_type"] == 2
 
-            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            constraint_mc_voltage_magnitude_setpoint(pm, i)
             for j in _PMs.ref(pm, :bus_gens, i)
-                _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
+                constraint_mc_active_gen_setpoint(pm, j)
             end
         end
     end
 
     for i in _PMs.ids(pm, :branch)
         constraint_mc_flow_losses(pm, i)
-
         constraint_mc_model_voltage_magnitude_difference(pm, i)
-
         constraint_mc_voltage_angle_difference(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
-        end
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
     end
 
     # Objective

--- a/src/prob/pf_lm.jl
+++ b/src/prob/pf_lm.jl
@@ -24,24 +24,19 @@ end
 
 ""
 function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
-    variable_mc_voltage(pm, bounded=false)
-    variable_mc_branch_flow(pm, bounded=false)
-    variable_mc_transformer_flow(pm, bounded=false)
-    variable_mc_load(pm, bounded=false)
-
-    for c in _PMs.conductor_ids(pm)
-        _PMs.variable_generation(pm, bounded=false, cnd=c)
-    end
+    variable_mc_voltage(pm; bounded=false)
+    variable_mc_branch_flow(pm; bounded=false)
+    variable_mc_transformer_flow(pm; bounded=false)
+    variable_mc_generation(pm; bounded=false)
+    variable_mc_load(pm; bounded=false)
 
     constraint_mc_model_voltage(pm)
 
     for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_mc_theta_ref(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            @assert bus["bus_type"] == 3
-            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-        end
+        @assert bus["bus_type"] == 3
+        constraint_mc_voltage_magnitude_setpoint(pm, i)
     end
 
     # loads should be constrained before KCL, or Pd/Qd undefined
@@ -52,16 +47,14 @@ function post_mc_pf_lm(pm::_PMs.AbstractPowerModel)
     for (i,bus) in _PMs.ref(pm, :bus)
         constraint_mc_power_balance_load(pm, i)
 
-        for c in _PMs.conductor_ids(pm)
-            # PV Bus Constraints
-            if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
-                # this assumes inactive generators are filtered out of bus_gens
-                @assert bus["bus_type"] == 2
+        # PV Bus Constraints
+        if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
+            # this assumes inactive generators are filtered out of bus_gens
+            @assert bus["bus_type"] == 2
 
-                _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-                for j in _PMs.ref(pm, :bus_gens, i)
-                    _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
-                end
+            constraint_mc_voltage_magnitude_setpoint(pm, i)
+            for j in _PMs.ref(pm, :bus_gens, i)
+                constraint_mc_active_gen_setpoint(pm, j)
             end
         end
     end

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -5,69 +5,65 @@
 #
 ######
 "multi-network opf with storage"
-function run_mn_mc_opf(data::Dict{String,Any}, model_type, solver; kwargs...)
-    return _PMs.run_model(data, model_type, solver, post_mn_mc_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
+function _run_mn_mc_opf(data::Dict{String,Any}, model_type, solver; kwargs...)
+    return _PMs.run_model(data, model_type, solver, _post_mn_mc_strg_opf; ref_extensions=[ref_add_arcs_trans!], multiconductor=true, multinetwork=true, kwargs...)
 end
 
 
-""
-function run_mn_mc_opf(file::String, model_type, solver; kwargs...)
+"multi-network opf with storage"
+function _run_mn_mc_opf(file::String, model_type, solver; kwargs...)
     return run_mn_mc_opf(PowerModelsDistribution.parse_file(file), model_type, solver; kwargs...)
 end
 
 
-""
-function post_mn_mc_strg_opf(pm::_PMs.AbstractPowerModel)
+"multi-network opf with storage"
+function _post_mn_mc_strg_opf(pm::_PMs.AbstractPowerModel)
     for (n, network) in _PMs.nws(pm)
-        variable_mc_voltage(pm, nw=n)
-        constraint_mc_model_voltage(pm, nw=n)
-        variable_mc_branch_flow(pm, nw=n)
-        variable_mc_storage(pm, nw=n)
+        variable_mc_voltage(pm; nw=n)
+        constraint_mc_model_voltage(pm; nw=n)
+        variable_mc_branch_flow(pm; nw=n)
+        variable_mc_generation(pm; nw=n)
+        variable_mc_storage(pm; nw=n)
 
-        for c in _PMs.conductor_ids(pm, nw=n)
-            _PMs.variable_generation(pm, cnd=c, nw=n)
-            _PMs.variable_dcline_flow(pm, cnd=c, nw=n)
+        for i in _PMs.ids(pm, :ref_buses; nw=n)
+            constraint_mc_theta_ref(pm, i; nw=n)
         end
 
-        for i in _PMs.ids(pm, :ref_buses, nw=n)
-            constraint_mc_theta_ref(pm, i, nw=n)
+        for i in _PMs.ids(pm, :bus; nw=n)
+            constraint_mc_power_balance(pm, i; nw=n)
         end
 
-        for i in _PMs.ids(pm, :bus, nw=n), c in _PMs.conductor_ids(pm, nw=n)
-            _PMs.constraint_power_balance(pm, i, cnd=c, nw=n)
+        for i in _PMs.ids(pm, :storage; nw=n)
+            _PMs.constraint_storage_state(pm, i; nw=n)
+            _PMs.constraint_storage_complementarity_nl(pm, i; nw=n)
+            constraint_mc_storage_loss(pm, i; nw=n)
+            constraint_mc_storage_thermal_limit(pm, i; nw=n)
         end
 
-        for i in _PMs.ids(pm, :storage, nw=n)
-            _PMs.constraint_storage_state(pm, i, nw=n)
-            _PMs.constraint_storage_complementarity_nl(pm, i, nw=n)
-            _PMs.constraint_storage_loss(pm, i, conductors=_PMs.conductor_ids(pm), nw=n)
-            for c in _PMs.conductor_ids(pm, nw=n)
-                _PMs.constraint_storage_thermal_limit(pm, i, cnd=c, nw=n)
-            end
+        for i in _PMs.ids(pm, :branch; nw=n)
+            constraint_mc_ohms_yt_from(pm, i; nw=n)
+            constraint_mc_ohms_yt_to(pm, i; nw=n)
+
+            constraint_mc_voltage_angle_difference(pm, i; nw=n)
+
+            constraint_mc_thermal_limit_from(pm, i; nw=n)
+            constraint_mc_thermal_limit_to(pm, i; nw=n)
         end
 
-        for i in _PMs.ids(pm, :branch, nw=n)
-            constraint_mc_ohms_yt_from(pm, i, nw=n)
-            constraint_mc_ohms_yt_to(pm, i, nw=n)
-
-            for c in _PMs.conductor_ids(pm, nw=n)
-                _PMs.constraint_voltage_angle_difference(pm, i, cnd=c, nw=n)
-
-                _PMs.constraint_thermal_limit_from(pm, i, cnd=c, nw=n)
-                _PMs.constraint_thermal_limit_to(pm, i, cnd=c, nw=n)
-            end
+        for i in _PMs.ids(pm, :transformer; nw=n)
+            constraint_mc_trans(pm, i; nw=n)
         end
     end
 
     network_ids = sort(collect(_PMs.nw_ids(pm)))
 
     n_1 = network_ids[1]
-    for i in _PMs.ids(pm, :storage, nw=n_1)
-        _PMs.constraint_storage_state(pm, i, nw=n_1)
+    for i in _PMs.ids(pm, :storage; nw=n_1)
+        _PMs.constraint_storage_state(pm, i; nw=n_1)
     end
 
     for n_2 in network_ids[2:end]
-        for i in _PMs.ids(pm, :storage, nw=n_2)
+        for i in _PMs.ids(pm, :storage; nw=n_2)
             _PMs.constraint_storage_state(pm, i, n_1, n_2)
         end
         n_1 = n_2

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -6,7 +6,7 @@
         PMD.make_multiconductor!(mp_data, 3)
         mn_mp_data = PowerModels.replicate(mp_data, 5)
 
-        result = PMD.run_mn_mc_opf(mn_mp_data, PowerModels.ACPPowerModel, ipopt_solver)
+        result = PMD._run_mn_mc_opf(mn_mp_data, PowerModels.ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == PMs.LOCALLY_SOLVED
         @test isapprox(result["objective"], 2.64596e5; atol = 1e2)


### PR DESCRIPTION
Removes any loops over conductors from the problem definitions to avoid confusing users. Loops over conductors, if needed, will happen inside of functions in `src/core/constraint_templates.jl` or `src/core/variables.jl`, particularly for those constraints/variables which merely call back to PowerModels.

Adds the following functions:

- `constraint_mc_storage_loss`
- `constraint_mc_storage_thermal_limit`
- `constraint_mc_thermal_limit_from`
- `constraint_mc_thermal_limit_to`
- `constraint_mc_voltage_magnitude_setpoint`
- `constraint_mv_active_gen_setpoint`
- `variable_mc_generation`
- `variable_mc_generation_on_off`

Fixes a multinetwork bug in `ref_add_arcs_trans!`

Adds an `AbstractWModels` version of `constraint_mc_power_balance`

Fixes multinetwork calls in constraint templates and variable constructors (`conductor_ids` should receive `nw` kwarg in multinetwork cases).

Multinetwork problem definition made to be internal, similar to how PowerModels does problem definitions in `src/prob/test.jl`, and updated unit test to use new function name.

No updates to unit tests were necessary.

Changelog updated