### PR TITLE
FIX: Branch flow solution building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Fixed `solution_bf!` for branch flow solution building (#182)
 - Refactored problem definitions to remove any explicit loops over conductors (#181)
 - Added data format documentation (#180)
 - Moved storage to main MLD and OPF problems (#179)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -37,3 +37,7 @@ function make_multiconductor!(mp_data, n_conductors::Int)
         end
     end
 end
+
+
+"Replaces NaN values with zeros"
+_replace_nan(v) = map(x -> isnan(x) ? zero(x) : x, v)

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -1,3 +1,5 @@
+import LinearAlgebra: tr
+
 "adds voltage balance indicators; should only be called after add_setpoint_bus_voltage!"
 function add_setpoint_bus_voltage_balance_indicators!(pm::_PMs.AbstractPowerModel, sol)
     sol_dict = _PMs.get(sol, "bus", Dict{String,Any}())
@@ -62,7 +64,7 @@ end
 
 
 ""
-function solution_tp!(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
+function solution_bf!(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
     add_setpoint_bus_voltage!(sol, pm)
     _PMs.add_setpoint_generator_power!(sol, pm)
     add_setpoint_branch_flow!(sol, pm)
@@ -92,20 +94,19 @@ end
 ""
 function add_setpoint_branch_flow!(sol, pm::_PMs.AbstractPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        _PMs.add_setpoint!(sol, pm, "branch", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "pf_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qf_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "pf_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qf_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf", :p; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf", :q; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf_ut", :p_ut; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf_ut", :q_ut; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf_lt", :p_lt; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf_lt", :q_lt; var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]), status_name="br_status")
 
-        _PMs.add_setpoint!(sol, pm, "branch", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "pt_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qt_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "pt_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "qt_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-
+        _PMs.add_setpoint!(sol, pm, "branch", "pt", :p; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt", :q; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pt_ut", :p_ut; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt_ut", :q_ut; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pt_lt", :p_lt; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt_lt", :q_lt; var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]), status_name="br_status")
     end
 end
 
@@ -114,9 +115,9 @@ end
 function add_setpoint_branch_current!(sol, pm::_PMs.AbstractPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
         _PMs.add_setpoint!(sol, pm, "branch", "ccm", :ccm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "cc", :ccm, status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "ccr", :ccmr, status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "cci", :ccmi, status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cc", :ccm; status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "ccr", :ccmr; status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cci", :ccmi; status_name="br_status")
     end
 end
 
@@ -223,7 +224,7 @@ function add_original_variables!(sol, pm::_PMs.AbstractPowerModel)
         Memento.error(_LOGGER, "deriving the original variables requires setting: branch_flows => true")
     end
 
-    for (nw, network) in pm._PMs.ref[:nw]
+    for (nw, network) in _PMs.nws(pm)
         #find rank-1 starting points
         ref_buses   = _find_ref_buses(pm, nw)
         #TODO develop code to start with any rank-1 W variable
@@ -274,7 +275,7 @@ function add_original_variables!(sol, pm::_PMs.AbstractPowerModel)
 
                 Pij = _make_full_matrix_variable(sol["branch"]["$l"]["pf"].values, sol["branch"]["$l"]["pf_lt"].values, sol["branch"]["$l"]["pf_ut"].values)
                 Qij = _make_full_matrix_variable(sol["branch"]["$l"]["qf"].values, sol["branch"]["$l"]["qf_lt"].values, sol["branch"]["$l"]["qf_ut"].values)
-                Sij = Pij + im*Qij
+                Sij = _replace_nan(Pij + im*Qij)
 
                 Ssij = Sij - Ui*Ui'*y_fr'
                 Isij = (1/tr(Ui*Ui'))*(Ssij')*Ui
@@ -311,7 +312,7 @@ function add_original_variables!(sol, pm::_PMs.AbstractPowerModel)
 
                 Pij = _make_full_matrix_variable(sol["branch"]["$l"]["pt"].values, sol["branch"]["$l"]["pt_lt"].values, sol["branch"]["$l"]["pt_ut"].values)
                 Qij = _make_full_matrix_variable(sol["branch"]["$l"]["qt"].values, sol["branch"]["$l"]["qt_lt"].values, sol["branch"]["$l"]["qt_ut"].values)
-                Sij = Pij + im*Qij
+                Sij = _replace_nan(Pij + im*Qij)
 
                 Ssij = Sij - Ui*Ui'*y_fr'
                 Isij = (1/tr(Ui*Ui'))*(Ssij')*Ui
@@ -320,7 +321,6 @@ function add_original_variables!(sol, pm::_PMs.AbstractPowerModel)
 
                 Isji = -Isij
                 Iji = Isji + y_to*Uj
-
 
                 sol["bus"]["$j"]["vm"] = abs.(Uj)
                 sol["bus"]["$j"]["va"] = _wrap_to_pi(angle.(Uj))

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -27,12 +27,65 @@ function constraint_mc_power_balance(pm::_PMs.AbstractActivePowerModel, nw::Int,
 end
 
 
-"storage loss constraint"
-function constraint_mc_storage_loss(pm::_PMs.AbstractActivePowerModel, n::Int, i, bus, r, x, standby_loss)
-    conductors = _PMs.conductor_ids(pm)
-    ps = [_PMs.var(pm, n, c, :ps, i) for c in conductors]
-    sc = _PMs.var(pm, n, :sc, i)
-    sd = _PMs.var(pm, n, :sd, i)
+######## Lossless Models ########
+"Create variables for the active power flowing into all transformer windings"
+function variable_mc_transformer_active_flow(pm::_PMs.AbstractAPLossLessModels; nw::Int=pm.cnw, bounded=true)
+    for cnd in _PMs.conductor_ids(pm)
+        pt = _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
+            [(l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)],
+            base_name="$(nw)_$(cnd)_p_trans",
+            start=0
+        )
+        if bounded
+            for arc in _PMs.ref(pm, nw, :arcs_from_trans)
+                tr_id = arc[1]
+                flow_lb  = -_PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
+                flow_ub  =  _PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
+                JuMP.set_lower_bound(pt[arc], flow_lb)
+                JuMP.set_upper_bound(pt[arc], flow_ub)
+            end
+        end
 
-    JuMP.@NLconstraint(pm.model, sum(ps[c] for c in conductors) + (sd - sc) == standby_loss + sum( r[c]*ps[c]^2 for c in conductors) )
+        for (l,branch) in _PMs.ref(pm, nw, :branch)
+            if haskey(branch, "pf_start")
+                f_idx = (l, branch["f_bus"], branch["t_bus"])
+                JuMP.set_value(p[f_idx], branch["pf_start"])
+            end
+        end
+
+        # this explicit type erasure is necessary
+        p_expr = Dict{Any,Any}( ((l,i,j), pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans) )
+        p_expr = merge(p_expr, Dict( ((l,j,i), -1.0*pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)))
+        _PMs.var(pm, nw, cnd)[:pt] = p_expr
+    end
+end
+
+
+"Do nothing, this model is symmetric"
+function constraint_mc_ohms_yt_to(pm::_PMs.AbstractAPLossLessModels, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+end
+
+### Network Flow Approximation ###
+"nothing to do, no voltage angle variables"
+function constraint_mc_theta_ref(pm::_PMs.AbstractNFAModel, n::Int, c::Int, d)
+end
+
+
+"nothing to do, no voltage angle variables"
+function constraint_mc_ohms_yt_from(pm::_PMs.AbstractNFAModel, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+end
+
+
+"nothing to do, this model is symmetric"
+function constraint_mc_ohms_yt_to(pm::_PMs.AbstractNFAModel, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+end
+
+
+"nothing to do, no voltage variables"
+function constraint_mc_transformer_voltage(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
+end
+
+
+"nothing to do, this model is symmetric"
+function constraint_mc_transformer_flow(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -15,50 +15,6 @@ function variable_mc_bus_voltage_on_off(pm::_PMs.AbstractDCPModel; kwargs...)
 end
 
 
-######## Lossless Models ########
-"Create variables for the active power flowing into all transformer windings"
-function variable_mc_transformer_active_flow(pm::_PMs.AbstractAPLossLessModels; nw::Int=pm.cnw, bounded=true)
-    for cnd in _PMs.conductor_ids(pm)
-        pt = _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
-            [(l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)],
-            base_name="$(nw)_$(cnd)_p_trans",
-            start=0
-        )
-        if bounded
-            for arc in _PMs.ref(pm, nw, :arcs_from_trans)
-                tr_id = arc[1]
-                flow_lb  = -_PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
-                flow_ub  =  _PMs.ref(pm, nw, :transformer, tr_id, "rate_a")[cnd]
-                JuMP.set_lower_bound(pt[arc], flow_lb)
-                JuMP.set_upper_bound(pt[arc], flow_ub)
-            end
-        end
-
-        for (l,branch) in _PMs.ref(pm, nw, :branch)
-            if haskey(branch, "pf_start")
-                f_idx = (l, branch["f_bus"], branch["t_bus"])
-                JuMP.set_value(p[f_idx], branch["pf_start"])
-            end
-        end
-
-        # this explicit type erasure is necessary
-        p_expr = Dict{Any,Any}( ((l,i,j), pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans) )
-        p_expr = merge(p_expr, Dict( ((l,j,i), -1.0*pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)))
-        _PMs.var(pm, nw, cnd)[:pt] = p_expr
-    end
-end
-
-
-"Do nothing, this model is symmetric"
-function constraint_mc_ohms_yt_to(pm::_PMs.AbstractAPLossLessModels, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
-end
-
-
-"Do nothing, this model is symmetric"
-function constraint_mc_ohms_yt_to_on_off(pm::_PMs.AbstractAPLossLessModels, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
-end
-
-
 ### DC Power Flow Approximation ###
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
@@ -73,45 +29,6 @@ function constraint_mc_ohms_yt_from(pm::_PMs.AbstractDCPModel, n::Int, c::Int, f
     va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
 
     JuMP.@constraint(pm.model, p_fr == -sum(b[c,d]*(va_fr[c] - va_to[d]) for d in _PMs.conductor_ids(pm)))
-    # omit reactive constraint
-end
-
-
-"`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"
-function constraint_mc_ohms_yt_from_on_off(pm::_PMs.AbstractDCPModel, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
-    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
-    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
-    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
-    z = [_PMs.var(pm, n, d, :branch_z, i) for d in _PMs.conductor_ids(pm)]
-
-    JuMP.@constraint(pm.model, p_fr <= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_max[d]*(1-z[d])) for d in _PMs.conductor_ids(pm)) )
-    JuMP.@constraint(pm.model, p_fr >= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_min[d]*(1-z[d])) for d in _PMs.conductor_ids(pm)) )
-end
-
-
-### Network Flow Approximation ###
-"nothing to do, no voltage angle variables"
-function constraint_mc_theta_ref(pm::_PMs.AbstractNFAModel, n::Int, c::Int, d)
-end
-
-
-"nothing to do, no voltage angle variables"
-function constraint_mc_ohms_yt_from(pm::_PMs.AbstractNFAModel, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
-end
-
-
-"nothing to do, this model is symmetric"
-function constraint_mc_ohms_yt_to(pm::_PMs.AbstractNFAModel, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
-end
-
-
-"nothing to do, no voltage variables"
-function constraint_mc_transformer_voltage(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to)
-end
-
-
-"nothing to do, this model is symmetric"
-function constraint_mc_transformer_flow(pm::_PMs.AbstractNFAModel, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to)
 end
 
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -189,7 +189,7 @@ end
 
 "delegate back to PowerModels"
 function constraint_mc_ohms_yt_from(pm::_PMs.AbstractWModels, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
-    _PMs.constraint_mc_ohms_yt_from(pm, n, c, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+    _PMs.constraint_ohms_yt_from(pm, n, c, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
 end
 
 

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -1,6 +1,6 @@
 ""
 function run_mc_opf_bf(data::Dict{String,Any}, model_type, solver; kwargs...)
-    return _PMs.run_model(data, model_type, solver, post_mc_opf_bf; solution_builder=solution_tp!, ref_extensions=[ref_add_arcs_trans!], multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_type, solver, post_mc_opf_bf; solution_builder=solution_bf!, ref_extensions=[ref_add_arcs_trans!], multiconductor=true, kwargs...)
 end
 
 

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -1,9 +1,9 @@
 ""
 function run_mc_pf_bf(data::Dict{String,Any}, model_type, solver; kwargs...)
-    if model_type != SDPUBFPowerModel && model_type != SOCNLPUBFPowerModel && model_type != SOCConicUBFPowerModel && model_type != LPUBFPowerModel && model_type != LPdiagUBFPowerModel && model_type !=  SOCBFPowerModel
+    if model_type != SDPUBFPowerModel && model_type != SOCNLPUBFPowerModel && model_type != SOCConicUBFPowerModel && model_type != LPLinUBFPowerModel && model_type != LPdiagUBFPowerModel && model_type !=  SOCBFPowerModel
         Memento.error(_LOGGER, "The problem type mc_opf_bf at the moment only supports a limited set of formulations")
     end
-    return _PMs.run_model(data, model_type, solver, post_mc_pf_bf; solution_builder=solution_tp!, ref_extensions=[ref_add_arcs_trans!], multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_type, solver, post_mc_pf_bf; solution_builder=solution_bf!, ref_extensions=[ref_add_arcs_trans!], multiconductor=true, kwargs...)
 end
 
 
@@ -28,7 +28,7 @@ function post_mc_pf_bf(pm::_PMs.AbstractPowerModel)
         constraint_mc_theta_ref(pm, i)
 
         @assert bus["bus_type"] == 3
-        # constraint_mc_voltage_magnitude_setpoint(pm, i) #TODO add back
+        constraint_mc_voltage_magnitude_setpoint(pm, i)
     end
 
     for i in _PMs.ids(pm, :bus)

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -236,3 +236,17 @@
         end
     end
 end
+
+@testset "test pf_bf" begin
+    @testset "test opendss pf_bf" begin
+        @testset "3-bus unbalanced acp pf_bf branch_flows original_variables" begin
+            pmd = PMD.parse_file("../test/data/opendss/case3_unbalanced.dss")
+            sol = PMD.run_mc_pf_bf(pmd, LPLinUBFPowerModel, ipopt_solver, setting=Dict("output"=>Dict("branch_flows"=>true, "original_variables"=>true)))
+
+            @test sol["termination_status"] == PMs.LOCALLY_SOLVED
+            @test isapprox(sol["objective"], 0.0209; atol=1e-4)
+            @test all(isapprox.(sol["solution"]["bus"]["1"]["vm"], 0.9959; atol=1e-4))
+            @test all(haskey(sol["solution"]["branch"]["1"],key) for key in [ "qf_ut" "pt" "qt_lt" "cci" "ccr" "ctm" "cta" "qt_ut" "qf_lt" "pt_lt" "pf_lt" "ccm" "cfm" "cc" "qf" "pt_ut" "qt" "cfa" "pf" "pf_ut" ])
+        end
+    end
+end


### PR DESCRIPTION
Adds unit test that covers `pf_bf` and solution builders with `branch_flow` and `original_variables` options enabled.

Fixes bugs in solution builders where depreciated kwargs were used in `add_setpoint!`.

Removes unused functions that don't seem to have any future purpose.

Specifically, removes `constraint_mc_ohms_yt_on_off` variants, since we have gone in a different direction since these were introduced and OTS spec was removed.

Updates changelog and adds unit test