### PR TITLE
ADD: count_nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ PowerModelsDistribution.jl Change Log
 ===================================
 
 ### staged
+- Adds `count_nodes` function to count the number of nodes in a parsed network (#183)
+- Exports `find_bus` and `find_component` functions for better user experience (#183)
 - Fixed `solution_bf!` for branch flow solution building (#182)
 - Refactored problem definitions to remove any explicit loops over conductors (#181)
 - Added data format documentation (#180)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -41,3 +41,75 @@ end
 
 "Replaces NaN values with zeros"
 _replace_nan(v) = map(x -> isnan(x) ? zero(x) : x, v)
+
+
+"Counts number of nodes in network"
+function count_nodes(dss_data::Dict{String,Array})::Int
+    sourcebus = get(dss_data["circuit"][1], "bus1", "sourcebus")
+    all_nodes = Dict()
+    for comp_type in values(dss_data)
+        for comp in values(comp_type)
+            if isa(comp, Dict) && haskey(comp, "buses")
+                for busname in values(_parse_array(String, comp["buses"]))
+                    name, nodes = _parse_busname(busname)
+
+                    if !haskey(all_nodes, name)
+                        all_nodes[name] = Set([])
+                    end
+
+                    for (n, node) in enumerate(nodes[1:3])
+                        if node
+                            push!(all_nodes[name], n)
+                        end
+                    end
+                end
+            elseif isa(comp, Dict)
+                for (prop, val) in comp
+                    if startswith(prop, "bus") && prop != "buses"
+                        name, nodes = _parse_busname(val)
+
+                        if !haskey(all_nodes, name)
+                            all_nodes[name] = Set([])
+                        end
+
+                        for (n, node) in enumerate(nodes[1:3])
+                            if node
+                                push!(all_nodes[name], n)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    n_nodes = 0
+    for (name, phases) in all_nodes
+        if name != sourcebus
+            n_nodes += length(phases)
+        end
+    end
+
+    return n_nodes
+end
+
+
+"Counts number of nodes in network"
+function count_nodes(pmd_data::Dict{String,Any})::Int
+    if pmd_data["source_type"] == "dss"
+        Memento.info(_LOGGER, "counting nodes from PowerModelsDistribution structure may not be as accurate as directly from `parse_dss` data due to virtual buses, etc.")
+    end
+
+    n_nodes = 0
+    for bus in values(pmd_data["bus"])
+        if pmd_data["source_type"] == "matlab"
+            n_nodes += sum(bus["vm"] .> 0.0)
+        elseif pmd_data["source_type"] == "dss"
+            if !(pmd_data["source_type"] == "dss" && bus["name"] in ["virtual_sourcebus", pmd_data["sourcebus"]]) && !(pmd_data["source_type"] == "dss" && startswith(bus["name"], "tr") && endswith(bus["name"], r"_b\d"))
+                n_nodes += sum(bus["vm"] .> 0.0)
+            end
+        end
+    end
+
+    return n_nodes
+end

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -1032,7 +1032,7 @@ function _apply_like!(raw_dss, dss_data, comp_type)
             end
 
             if prop in links
-                linked_dss = _find_component(dss_data, raw_dss[prop], comp_type)
+                linked_dss = find_component(dss_data, raw_dss[prop], comp_type)
                 if isempty(linked_dss)
                     Memento.warn(_LOGGER, "$comp_type.$(raw_dss["name"]): $prop=$(raw_dss[prop]) cannot be found")
                 else

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -133,12 +133,12 @@ end
 
 
 """
-    _find_component(pmd_data, name, compType)
+    find_component(pmd_data, name, compType)
 
 Returns the component of `compType` with `name` from `data` of type
 Dict{String,Array}.
 """
-function _find_component(data::Dict, name::AbstractString, compType::AbstractString)::Dict
+function find_component(data::Dict, name::AbstractString, compType::AbstractString)::Dict
     for comp in values(data[compType])
         if comp["name"] == name
             return comp
@@ -150,12 +150,12 @@ end
 
 
 """
-    _find_bus(busname, pmd_data)
+    find_bus(busname, pmd_data)
 
 Finds the index number of the bus in existing data from the given `busname`.
 """
-function _find_bus(busname::AbstractString, pmd_data::Dict)
-    bus = _find_component(pmd_data, busname, "bus")
+function find_bus(busname::AbstractString, pmd_data::Dict)
+    bus = find_component(pmd_data, busname, "bus")
     if haskey(bus, "bus_i")
         return bus["bus_i"]
     else
@@ -191,7 +191,7 @@ function _dss2pmd_load!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         end
 
         loadDict["name"] = defaults["name"]
-        loadDict["load_bus"] = _find_bus(name, pmd_data)
+        loadDict["load_bus"] = find_bus(name, pmd_data)
 
         load_name = defaults["name"]
 
@@ -352,7 +352,7 @@ function _dss2pmd_shunt!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         # now convent b_cap to per unit
         b_cap_pu = b_cap/Ybase_ln
 
-        shuntDict["shunt_bus"] = _find_bus(name, pmd_data)
+        shuntDict["shunt_bus"] = find_bus(name, pmd_data)
         shuntDict["name"] = defaults["name"]
         shuntDict["gs"] = _PMs.MultiConductorVector(_parse_array(0.0, nodes, nconductors))  # TODO:
         shuntDict["bs"] = _PMs.MultiConductorVector(_parse_array(b_cap_pu, nodes, nconductors))
@@ -382,7 +382,7 @@ function _dss2pmd_shunt!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
             Zbase = (pmd_data["basekv"] / sqrt(3.0))^2 * nconductors / pmd_data["baseMVA"]  # Use single-phase base impedance for each phase
             Gcap = Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (pmd_data["basekv"] / sqrt(3.0))^2)
 
-            shuntDict["shunt_bus"] = _find_bus(name, pmd_data)
+            shuntDict["shunt_bus"] = find_bus(name, pmd_data)
             shuntDict["name"] = defaults["name"]
             shuntDict["gs"] = _PMs.MultiConductorVector(_parse_array(0.0, nodes, nconductors))  # TODO:
             shuntDict["bs"] = _PMs.MultiConductorVector(_parse_array(Gcap, nodes, nconductors))
@@ -420,7 +420,7 @@ function _dss2pmd_gen!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
     nconductors = pmd_data["conductors"]
     name, nodes = _parse_busname(defaults["bus1"])
 
-    genDict["gen_bus"] = _find_bus("virtual_sourcebus", pmd_data)
+    genDict["gen_bus"] = find_bus("virtual_sourcebus", pmd_data)
     genDict["name"] = defaults["name"]
     genDict["gen_status"] = convert(Int, defaults["enabled"])
 
@@ -460,7 +460,7 @@ function _dss2pmd_gen!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         nconductors = pmd_data["conductors"]
         name, nodes = _parse_busname(defaults["bus1"])
 
-        genDict["gen_bus"] = _find_bus(name, pmd_data)
+        genDict["gen_bus"] = find_bus(name, pmd_data)
         genDict["name"] = defaults["name"]
         genDict["gen_status"] = convert(Int, defaults["enabled"])
         genDict["pg"] = _PMs.MultiConductorVector(_parse_array(defaults["kw"] / (1e3 * nconductors), nodes, nconductors))
@@ -526,7 +526,7 @@ function _dss2pmd_gen!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         name, nodes = _parse_busname(defaults["bus1"])
 
         pvDict["name"] = defaults["name"]
-        pvDict["gen_bus"] = _find_bus(name, pmd_data)
+        pvDict["gen_bus"] = find_bus(name, pmd_data)
 
         pvDict["pg"] = _PMs.MultiConductorVector(_parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
         pvDict["qg"] = _PMs.MultiConductorVector(_parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
@@ -577,7 +577,7 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         if haskey(line, "linecode")
             linecode = deepcopy(_get_linecode(dss_data, get(line, "linecode", "")))
             if haskey(linecode, "like")
-                linecode = merge(_find_component(dss_data, linecode["like"], "linecode"), linecode)
+                linecode = merge(find_component(dss_data, linecode["like"], "linecode"), linecode)
             end
 
             linecode["units"] = get(line, "units", "none") == "none" ? "none" : get(linecode, "units", "none")
@@ -609,8 +609,8 @@ function _dss2pmd_branch!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
 
         branchDict["name"] = defaults["name"]
 
-        branchDict["f_bus"] = _find_bus(bf, pmd_data)
-        branchDict["t_bus"] = _find_bus(bt, pmd_data)
+        branchDict["f_bus"] = find_bus(bf, pmd_data)
+        branchDict["t_bus"] = find_bus(bt, pmd_data)
 
         branchDict["length"] = defaults["length"]
 
@@ -719,7 +719,7 @@ function _dss2pmd_transformer!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
                 transDict["active_phases"] = [1, 2, 3]
                 Memento.warn(_LOGGER, "Only three-phase transformers are supported. The bus specification $bnstr is treated as $bus instead.")
             end
-            transDict["buses"][i] = _find_bus(bus, pmd_data)
+            transDict["buses"][i] = find_bus(bus, pmd_data)
         end
 
         # voltage and power ratings
@@ -913,8 +913,8 @@ function _dss2pmd_reactor!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
                 t_bus = _parse_busname(defaults["bus2"])[1]
 
                 reactDict["name"] = defaults["name"]
-                reactDict["f_bus"] = _find_bus(f_bus, pmd_data)
-                reactDict["t_bus"] = _find_bus(t_bus, pmd_data)
+                reactDict["f_bus"] = find_bus(f_bus, pmd_data)
+                reactDict["t_bus"] = find_bus(t_bus, pmd_data)
 
                 reactDict["br_r"] = _PMs.MultiConductorMatrix(_parse_matrix(diagm(0 => fill(0.2, nconductors)), nodes, nconductors))
                 reactDict["br_x"] = _PMs.MultiConductorMatrix(_parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
@@ -978,7 +978,7 @@ function _dss2pmd_pvsystem!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         name, nodes = _parse_busname(defaults["bus1"])
 
         pvsystemDict["name"] = defaults["name"]
-        pvsystemDict["pv_bus"] = _find_bus(name, pmd_data)
+        pvsystemDict["pv_bus"] = find_bus(name, pmd_data)
         pvsystemDict["p"] = _PMs.MultiConductorVector(_parse_array(defaults["kw"] / 1e3, nodes, nconductors))
         pvsystemDict["q"] = _PMs.MultiConductorVector(_parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
         pvsystemDict["status"] = convert(Int, defaults["enabled"])
@@ -1016,7 +1016,7 @@ function _dss2pmd_storage!(pmd_data::Dict, dss_data::Dict, import_all::Bool)
         name, nodes = _parse_busname(defaults["bus1"])
 
         storageDict["name"] = defaults["name"]
-        storageDict["storage_bus"] = _find_bus(name, pmd_data)
+        storageDict["storage_bus"] = find_bus(name, pmd_data)
         storageDict["energy"] = defaults["kwhstored"] / 1e3
         storageDict["energy_rating"] = defaults["kwhrated"] / 1e3
         storageDict["charge_rating"] = defaults["%charge"] * defaults["kwrated"] / 1e3 / 100.0
@@ -1061,7 +1061,7 @@ was adjusted to accomodate that.
 """
 function _adjust_sourcegen_bounds!(pmd_data)
     emergamps = Array{Float64,1}([0.0])
-    sourcebus_n = _find_bus(pmd_data["sourcebus"], pmd_data)
+    sourcebus_n = find_bus(pmd_data["sourcebus"], pmd_data)
     for (_,line) in pmd_data["branch"]
         if (line["f_bus"] == sourcebus_n || line["t_bus"] == sourcebus_n) && !startswith(line["source_id"], "virtual")
             append!(emergamps, get(line, "c_rating_b", get(line, "rate_b", missing)).values)
@@ -1588,8 +1588,8 @@ end
 
 "Creates a virtual branch between the `virtual_sourcebus` and `sourcebus` with the impedance given by `circuit`"
 function _create_sourcebus_vbranch!(pmd_data::Dict, circuit::Dict)
-    sourcebus = _find_bus(pmd_data["sourcebus"], pmd_data)
-    vsourcebus = _find_bus("virtual_sourcebus", pmd_data)
+    sourcebus = find_bus(pmd_data["sourcebus"], pmd_data)
+    vsourcebus = find_bus("virtual_sourcebus", pmd_data)
 
     br_r = _PMs.MultiConductorMatrix(circuit["rmatrix"])
     br_x = _PMs.MultiConductorMatrix(circuit["xmatrix"])

--- a/test/data.jl
+++ b/test/data.jl
@@ -66,5 +66,8 @@
         @test count_nodes(dss) == 7
         @test count_nodes(dss) == count_nodes(pmd)
         @test count_nodes(matlab) == 15
+
+        dss = PMD.parse_dss("../test/data/opendss/ut_trans_2w_yy.dss")
+        @test count_nodes(dss) == 9
     end
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -57,4 +57,14 @@
             @test isapprox(A, B)
         end
     end
+
+    @testset "node counting functions" begin
+        dss = PMD.parse_dss("../test/data/opendss/case5_phase_drop.dss")
+        pmd = PMD.parse_file("../test/data/opendss/case5_phase_drop.dss")
+        matlab = PMD.parse_file("../test/data/matlab/case5_i_r_b.m")
+
+        @test count_nodes(dss) == 7
+        @test count_nodes(dss) == count_nodes(pmd)
+        @test count_nodes(matlab) == 15
+    end
 end


### PR DESCRIPTION
Adds a function to count the number of nodes in a system, `count_nodes`.

Also exposes `find_bus` and `find_component` functions for export (previous only internal functions), to improve the user experience.

Adds unit tests and updates changelog