### PR TITLE
FIX: Voltage at virtual_sourcebus should be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Updates virtual_sourcebus, which is intended to represent a voltage source, to have a fixed voltage magnitude (#246,#248)
 - Add parsing of series data files into array fields in OpenDSS parser
 - Add LoadShape parsing to OpenDSS parser (#247)
 - The pf and opf problem specifications now contain delta connected, and voltage-dependent load models by default; pf_lm and opf_lm were removed.

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -111,8 +111,6 @@ function _dss2pmd_bus!(pmd_data::Dict, dss_data::Dict, import_all::Bool=false, v
     nodes = Array{Bool}([1 1 1 0])
     ph1_ang = circuit["angle"]
     vm = circuit["pu"]
-    vmi = circuit["pu"] - circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"])
-    vma = circuit["pu"] + circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"])
 
     busDict["bus_i"] = length(pmd_data["bus"])+1
     busDict["index"] = length(pmd_data["bus"])+1
@@ -123,8 +121,8 @@ function _dss2pmd_bus!(pmd_data::Dict, dss_data::Dict, import_all::Bool=false, v
     busDict["vm"] = _parse_array(vm, nodes, nconductors)
     busDict["va"] = _parse_array([_wrap_to_180(-rad2deg(2*pi/nconductors*(i-1))+ph1_ang) for i in 1:nconductors], nodes, nconductors)
 
-    busDict["vmin"] = _parse_array(vmi, nodes, nconductors, vmi)
-    busDict["vmax"] = _parse_array(vma, nodes, nconductors, vma)
+    busDict["vmin"] = _parse_array(vm, nodes, nconductors, vm)
+    busDict["vmax"] = _parse_array(vm, nodes, nconductors, vm)
 
     busDict["base_kv"] = pmd_data["basekv"]
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -145,8 +145,8 @@
             @test all(isapprox.(sol["solution"]["bus"]["2"]["vm"], 0.984377; atol=1e-4))
             @test all(isapprox.(sol["solution"]["bus"]["2"]["va"], PMD._wrap_to_pi.([2 * pi / pmd["conductors"] * (1 - c) - deg2rad(0.79) for c in 1:pmd["conductors"]]); atol=deg2rad(0.2)))
 
-            @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018209; atol=1e-5)
-            @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.000208979; atol=1e-5)
+            @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0181409; atol=1e-5)
+            @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.0; atol=1e-4)
         end
 
         @testset "3-bus balanced acp opf" begin
@@ -160,8 +160,8 @@
                 @test all(isapprox.(sol["solution"]["bus"][bus]["vm"], vm; atol=1e-4))
             end
 
-            @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018345; atol=1e-6)
-            @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00919404; atol=1.2e-5)
+            @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018276; atol=1e-6)
+            @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.008922; atol=1.2e-5)
         end
 
         @testset "3-bus unbalanced acp opf" begin
@@ -186,7 +186,7 @@
             sol = PMD.run_mc_opf(pmd, PMs.ACPPowerModel, ipopt_solver)
 
             @test sol["termination_status"] == PMs.LOCALLY_SOLVED
-            @test isapprox(sol["objective"], 0.0183961; atol=1e-4)
+            @test isapprox(sol["objective"], 0.0185; atol=1e-4)
         end
 
         @testset "3-bus balanced pv acp opf" begin


### PR DESCRIPTION
Because the sourcebus is a voltage source with an internal impedance
that we model as a virtual sourcebus connected to a virtual branch
connected to the real sourcebus, the virtual sourcebus should have
a fixed voltage.

To remedy this, `vmin` and `vmax` at the virtual_sourcebus are fixed
to `vm`, i.e. `vmin==vmax==vm`.

Only three OPF test cases needed to be updated, and none of the
voltages in those test cases needed to change:

- 2-bus diagonal acp opf
- 3-bus balanced acp opf
- 3-bus unbalanced isc acp opf

Updates unit tests and changelog

Closes #246 