### PR TITLE
ADD: Buscoord parsing into PMD data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Add automatic parsing of lon,lat from buscoords file into PMD data structure (#245, #249)
 - Updates virtual_sourcebus, which is intended to represent a voltage source, to have a fixed voltage magnitude (#246,#248)
 - Add parsing of series data files into array fields in OpenDSS parser
 - Add LoadShape parsing to OpenDSS parser (#247)

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -642,10 +642,9 @@ function _parse_buscoords(file::AbstractString)::Array
     coordArray = []
     for line in lines
         bus, x, y = split(line, regex; limit=3)
-        push!(coordArray, Dict{String,Any}("bus"=>strip(bus, [',']),
-                                            "name"=>strip(bus, [',']),
-                                            "x"=>parse(Float64, strip(x, [','])),
-                                            "y"=>parse(Float64, strip(y, [',', '\r']))))
+        push!(coordArray, Dict{String,Any}("name"=>lowercase(strip(bus, [','])),
+                                           "x"=>parse(Float64, strip(x, [','])),
+                                           "y"=>parse(Float64, strip(y, [',', '\r']))))
     end
     return coordArray
 end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -1689,6 +1689,16 @@ function _bank_transformers!(pmd_data::Dict)
 end
 
 
+"Parses buscoords [lon,lat] (if present) into their respective buses"
+function _dss2pmd_buscoords!(pmd_data::Dict, dss_data::Dict)
+    for bc in get(dss_data, "buscoords", [])
+        bus = pmd_data["bus"]["$(find_bus(bc["name"], pmd_data))"]
+        bus["lon"] = bc["x"]
+        bus["lat"] = bc["y"]
+    end
+end
+
+
 """
     parse_options(options)
 
@@ -1764,6 +1774,8 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
     pmd_data["switch"] = []
 
     InfrastructureModels.arrays_to_dicts!(pmd_data)
+
+    _dss2pmd_buscoords!(pmd_data, dss_data)
 
     if bank_transformers
         _bank_transformers!(pmd_data)

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -134,7 +134,7 @@
     cmatrix = PMD._parse_matrix(Float64, "[8.0000  |-2.00000  9.000000  |-1.75000  -2.50000  8.00000  ]") / 3
 
     @testset "buscoords automatic parsing" begin
-        @test all(haskey(bus, "lon") && haskey(bus, "lat") for bus in values(pmd["bus"]) if "bus_i" in collect(range(1,10; step=1)))
+        @test all(haskey(bus, "lon") && haskey(bus, "lat") for bus in values(pmd["bus"]) if "bus_i" in 1:10)
     end
 
     @testset "opendss parse generic parser verification" begin

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -133,6 +133,10 @@
     xmatrix=PMD._parse_matrix(Float64, "[1.0000  |0.500000  0.50000  |0.500000  0.50000  1.000000  ]") * 3
     cmatrix = PMD._parse_matrix(Float64, "[8.0000  |-2.00000  9.000000  |-1.75000  -2.50000  8.00000  ]") / 3
 
+    @testset "buscoords automatic parsing" begin
+        @test all(haskey(bus, "lon") && haskey(bus, "lat") for bus in values(pmd["bus"]) if "bus_i" in collect(range(1,10; step=1)))
+    end
+
     @testset "opendss parse generic parser verification" begin
         dss = PMD.parse_dss("../test/data/opendss/test2_master.dss")
 


### PR DESCRIPTION
Adds automatic parsing of buscoords (if present) into the PMD data
structure, under the fields `lon` and `lat`.

Adds unit test using existing opendss test files and updates changelog.

Removes `buscoords.dat` from test data files, it does not seem to
be used.

Closes #245