### PR TITLE
Updates for PowerModels v0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## staged
 
+- nothing
+
+## v0.9.0
+
+- Update to PowerModels v0.16
 - Add support for Memento v0.13, v1.0
 
 ## v0.8.1

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PowerModelsDistribution"
 uuid = "d7431456-977f-11e9-2de3-97ff7677985e"
 authors = ["David M Fobes <dfobes@lanl.gov>", "Carleton Coffrin"]
 repo = "https://github.com/lanl-ansi/PowerModelsDistribution.jl.git"
-version = "0.8.1"
+version = "0.9.0"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -23,7 +23,7 @@ JuMP = "~0.19.2, ~0.20, ~0.21"
 Juniper = ">= 0.4"
 MathOptInterface = "~0.8, ~0.9"
 Memento = "~0.10, ~0.11, ~0.12, ~0.13, ~1.0"
-PowerModels = "~0.15"
+PowerModels = "~0.16"
 SCS = ">= 0.4"
 julia = "^1"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,3 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 
-[compat]
-InfrastructureModels = "~0.4"
-PowerModels = "~0.15"

--- a/docs/src/quickguide.md
+++ b/docs/src/quickguide.md
@@ -41,7 +41,7 @@ The following example demonstrates how to break a `run_mc_opf` call into seperat
 
 ```julia
 data = PowerModelsDistribution.parse_file("case3_unbalanced.dss")
-pm = PowerModels.instantiate_model(data, ACPPowerModel, PowerModelsDistribution.build_mc_opf; multiconductor=true, ref_extensions=[ref_add_arcs_trans!])
+pm = PowerModels.instantiate_model(data, ACPPowerModel, PowerModelsDistribution.build_mc_opf; ref_extensions=[ref_add_arcs_trans!])
 print(pm.model)
 optimize_model!(pm, optimizer=with_optimizer(Ipopt.Optimizer))
 ```

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -10,7 +10,7 @@ function constraint_mc_thermal_limit_from(pm::_PMs.AbstractPowerModel, n::Int, f
 
     mu_sm_fr = JuMP.@constraint(pm.model, p_fr.^2 + q_fr.^2 .<= rate_a.^2)
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, n, :branch, f_idx[1])[:mu_sm_fr] = mu_sm_fr
     end
 end
@@ -22,7 +22,7 @@ function constraint_mc_thermal_limit_to(pm::_PMs.AbstractPowerModel, n::Int, t_i
 
     mu_sm_to = JuMP.@constraint(pm.model, p_to.^2 + q_to.^2 .<= rate_a.^2)
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, n, :branch, t_idx[1])[:mu_sm_to] = mu_sm_to
     end
 end

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -42,20 +42,29 @@ end
 
 
 "Adds arcs for PMD transformers; for dclines and branches this is done in PMs"
-function ref_add_arcs_trans!(pm::_PMs.AbstractPowerModel)
-    for nw in _PMs.nw_ids(pm)
-        if !haskey(_PMs.ref(pm, nw), :transformer)
+function ref_add_arcs_trans!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
+    if InfrastructureModels.ismultinetwork(data)
+        nws_data = data["nw"]
+    else
+        nws_data = Dict("0" => data)
+    end
+
+    for (n, nw_data) in nws_data
+        nw_id = parse(Int, n)
+        nw_ref = ref[:nw][nw_id]
+
+        if !haskey(nw_ref, :transformer)
             # this might happen when parsing data from matlab format
             # the OpenDSS parser always inserts a trans dict
-            _PMs.ref(pm, nw)[:transformer] = Dict{Int, Any}()
+            nw_ref[:transformer] = Dict{Int, Any}()
         end
         # dirty fix add arcs_from/to_trans and bus_arcs_trans
-        pm.ref[:nw][nw][:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in _PMs.ref(pm, nw, :transformer)]
-        pm.ref[:nw][nw][:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in _PMs.ref(pm, nw, :transformer)]
-        pm.ref[:nw][nw][:arcs_trans] = [pm.ref[:nw][nw][:arcs_from_trans]..., pm.ref[:nw][nw][:arcs_to_trans]...]
-        pm.ref[:nw][nw][:bus_arcs_trans] = Dict{Int64, Array{Any, 1}}()
-        for i in _PMs.ids(pm, nw, :bus)
-            pm.ref[:nw][nw][:bus_arcs_trans][i] = [e for e in pm.ref[:nw][nw][:arcs_trans] if e[2]==i]
+        nw_ref[:arcs_from_trans] = [(i, trans["f_bus"], trans["t_bus"]) for (i,trans) in nw_ref[:transformer]]
+        nw_ref[:arcs_to_trans] = [(i, trans["t_bus"], trans["f_bus"]) for (i,trans) in nw_ref[:transformer]]
+        nw_ref[:arcs_trans] = [nw_ref[:arcs_from_trans]..., nw_ref[:arcs_to_trans]...]
+        nw_ref[:bus_arcs_trans] = Dict{Int64, Array{Any, 1}}()
+        for (i,bus) in nw_ref[:bus]
+            nw_ref[:bus_arcs_trans][i] = [e for e in nw_ref[:arcs_trans] if e[2]==i]
         end
     end
 end

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -24,7 +24,7 @@ function variable_mc_voltage_angle(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, 
         ) for i in _PMs.ids(pm, nw, :bus)
     )
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :va, _PMs.ids(pm, nw, :bus), va)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :va, _PMs.ids(pm, nw, :bus), va)
 end
 
 ""
@@ -49,7 +49,7 @@ function variable_mc_voltage_magnitude(pm::_PMs.AbstractPowerModel; nw::Int=pm.c
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :vm, _PMs.ids(pm, nw, :bus), vm)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :vm, _PMs.ids(pm, nw, :bus), vm)
 end
 
 ""
@@ -72,7 +72,7 @@ function variable_mc_voltage_real(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, b
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :vr, _PMs.ids(pm, nw, :bus), vr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :vr, _PMs.ids(pm, nw, :bus), vr)
 end
 
 ""
@@ -95,7 +95,7 @@ function variable_mc_voltage_imaginary(pm::_PMs.AbstractPowerModel; nw::Int=pm.c
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :vi, _PMs.ids(pm, nw, :bus), vi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :vi, _PMs.ids(pm, nw, :bus), vi)
 end
 
 
@@ -135,7 +135,7 @@ function variable_mc_branch_flow_active(pm::_PMs.AbstractPowerModel; nw::Int=pm.
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :pf, :pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), p)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :pf, :pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), p)
 end
 
 "variable: `q[l,i,j]` for `(l,i,j)` in `arcs`"
@@ -168,7 +168,7 @@ function variable_mc_branch_flow_reactive(pm::_PMs.AbstractPowerModel; nw::Int=p
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :qf, :qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), q)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :qf, :qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), q)
 end
 
 
@@ -193,7 +193,7 @@ function variable_mc_branch_current_real(pm::_PMs.AbstractPowerModel; nw::Int=pm
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :cr_fr, :cr_to, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), cr)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :cr_fr, :cr_to, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), cr)
 end
 
 
@@ -218,7 +218,7 @@ function variable_mc_branch_current_imaginary(pm::_PMs.AbstractPowerModel; nw::I
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :ci_fr, :ci_to, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), ci)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :ci_fr, :ci_to, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), ci)
 end
 
 
@@ -243,7 +243,7 @@ function variable_mc_branch_series_current_real(pm::_PMs.AbstractPowerModel; nw:
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :branch, :csr_fr, _PMs.ids(pm, nw, :branch), csr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :branch, :csr_fr, _PMs.ids(pm, nw, :branch), csr)
 end
 
 
@@ -268,7 +268,7 @@ function variable_mc_branch_series_current_imaginary(pm::_PMs.AbstractPowerModel
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :branch, :csi_fr, _PMs.ids(pm, nw, :branch), csi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :branch, :csi_fr, _PMs.ids(pm, nw, :branch), csi)
 end
 
 
@@ -298,7 +298,7 @@ function variable_mc_transformer_current_real(pm::_PMs.AbstractPowerModel; nw::I
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :cr_fr, :cr_to, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), cr)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :cr_fr, :cr_to, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), cr)
 end
 
 
@@ -328,7 +328,7 @@ function variable_mc_transformer_current_imaginary(pm::_PMs.AbstractPowerModel; 
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :ci_fr, :ci_to, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), ci)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :ci_fr, :ci_to, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), ci)
 end
 
 
@@ -363,7 +363,7 @@ function variable_mc_voltage_magnitude_sqr(pm::_PMs.AbstractPowerModel; nw::Int=
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :w, _PMs.ids(pm, nw, :bus), w)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :w, _PMs.ids(pm, nw, :bus), w)
 end
 
 
@@ -402,7 +402,7 @@ function variable_mc_storage_active(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw,
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :storage, :ps, _PMs.ids(pm, nw, :storage), ps)
+    report && InfrastructureModels.sol_component_value(pm, nw, :storage, :ps, _PMs.ids(pm, nw, :storage), ps)
 end
 
 function variable_mc_storage_reactive(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
@@ -430,7 +430,7 @@ function variable_mc_storage_reactive(pm::_PMs.AbstractPowerModel; nw::Int=pm.cn
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :storage, :qs, _PMs.ids(pm, nw, :storage), qs)
+    report && InfrastructureModels.sol_component_value(pm, nw, :storage, :qs, _PMs.ids(pm, nw, :storage), qs)
 end
 
 
@@ -453,7 +453,7 @@ function variable_mc_active_bus_power_slack(pm::_PMs.AbstractPowerModel; nw::Int
         ) for i in _PMs.ids(pm, nw, :bus)
     )
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :p_slack, _PMs.ids(pm, nw, :bus), p_slack)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :p_slack, _PMs.ids(pm, nw, :bus), p_slack)
 end
 
 
@@ -468,7 +468,7 @@ function variable_mc_reactive_bus_power_slack(pm::_PMs.AbstractPowerModel; nw::I
         ) for i in _PMs.ids(pm, nw, :bus)
     )
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :q_slack, _PMs.ids(pm, nw, :bus), q_slack)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :q_slack, _PMs.ids(pm, nw, :bus), q_slack)
 end
 
 
@@ -511,7 +511,7 @@ function variable_mc_transformer_flow_active(pm::_PMs.AbstractPowerModel; nw::In
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :pf, :pt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), pt)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :pf, :pt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), pt)
 end
 
 
@@ -549,7 +549,7 @@ function variable_mc_transformer_flow_reactive(pm::_PMs.AbstractPowerModel; nw::
         end
     end
 
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :qf, :qt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), qt)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :qf, :qt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), qt)
 end
 
 
@@ -573,7 +573,7 @@ function variable_mc_oltc_tap(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw, bound
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :transformer, :tap, _PMs.ids(pm, nw, :transformer), tap)
+    report && InfrastructureModels.sol_component_value(pm, nw, :transformer, :tap, _PMs.ids(pm, nw, :transformer), tap)
 end
 
 
@@ -615,9 +615,9 @@ function variable_mc_indicator_demand(pm::_PMs.AbstractPowerModel; nw::Int=pm.cn
     qd = _PMs.var(pm, nw)[:qd] = Dict(i => _PMs.var(pm, nw)[:z_demand][i].*_PMs.ref(pm, nw, :load, i)["qd"]
      for i in _PMs.ids(pm, nw, :load))
 
-    report && _PMs.sol_component_value(pm, nw, :load, :status, _PMs.ids(pm, nw, :load), z_demand)
-    report && _PMs.sol_component_value(pm, nw, :load, :pd, _PMs.ids(pm, nw, :load), pd)
-    report && _PMs.sol_component_value(pm, nw, :load, :qd, _PMs.ids(pm, nw, :load), qd)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :status, _PMs.ids(pm, nw, :load), z_demand)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :pd, _PMs.ids(pm, nw, :load), pd)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :qd, _PMs.ids(pm, nw, :load), qd)
 end
 
 
@@ -640,7 +640,7 @@ function variable_mc_indicator_shunt(pm::_PMs.AbstractPowerModel; nw::Int=pm.cnw
         )
     end
 
-    report && _PMs.sol_component_value(pm, nw, :shunt, :status, _PMs.ids(pm, nw, :shunt), z_shunt)
+    report && InfrastructureModels.sol_component_value(pm, nw, :shunt, :status, _PMs.ids(pm, nw, :shunt), z_shunt)
 end
 
 
@@ -661,7 +661,7 @@ function variable_mc_indicator_bus_voltage(pm::_PMs.AbstractPowerModel; nw::Int=
         )
     end
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :status, _PMs.ids(pm, nw, :bus), z_voltage)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :status, _PMs.ids(pm, nw, :bus), z_voltage)
 end
 
 
@@ -682,7 +682,7 @@ function variable_mc_indicator_generation(pm::_PMs.AbstractPowerModel; nw::Int=p
         )
     end
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :gen_status, _PMs.ids(pm, nw, :gen), z_gen)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :gen_status, _PMs.ids(pm, nw, :gen), z_gen)
 end
 
 
@@ -703,7 +703,7 @@ function variable_mc_indicator_storage(pm::_PMs.AbstractPowerModel; nw::Int=pm.c
         )
     end
 
-    report && _PMs.sol_component_value(pm, nw, :storage, :status, _PMs.ids(pm, nw, :storage), z_storage)
+    report && InfrastructureModels.sol_component_value(pm, nw, :storage, :status, _PMs.ids(pm, nw, :storage), z_storage)
 end
 
 
@@ -732,7 +732,7 @@ function variable_mc_on_off_storage_active(pm::_PMs.AbstractPowerModel; nw::Int=
         start = comp_start_value(_PMs.ref(pm, nw, :storage, i), "ps_start", cnd, 0.0)
     ) for i in _PMs.ids(pm, nw, :storage))
 
-    report && _PMs.sol_component_value(pm, nw, :storage, :ps, _PMs.ids(pm, nw, :storage), ps)
+    report && InfrastructureModels.sol_component_value(pm, nw, :storage, :ps, _PMs.ids(pm, nw, :storage), ps)
 end
 
 
@@ -748,7 +748,7 @@ function variable_mc_on_off_storage_reactive(pm::_PMs.AbstractPowerModel; nw::In
         start = comp_start_value(_PMs.ref(pm, nw, :storage, i), "qs_start", cnd, 0.0)
     ) for i in _PMs.ids(pm, nw, :storage))
 
-    report && _PMs.sol_component_value(pm, nw, :storage, :qs, _PMs.ids(pm, nw, :storage), qs)
+    report && InfrastructureModels.sol_component_value(pm, nw, :storage, :qs, _PMs.ids(pm, nw, :storage), qs)
 end
 
 
@@ -764,7 +764,7 @@ function variable_mc_voltage_magnitude_sqr_on_off(pm::_PMs.AbstractPowerModel; n
         start = comp_start_value(_PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
     ) for i in _PMs.ids(pm, nw, :bus))
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :w, _PMs.ids(pm, nw, :bus), w)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :w, _PMs.ids(pm, nw, :bus), w)
 end
 
 
@@ -780,7 +780,7 @@ function variable_mc_voltage_magnitude_on_off(pm::_PMs.AbstractPowerModel; nw::I
         start = comp_start_value(_PMs.ref(pm, nw, :bus, i), "vm_start", c, 1.0)
     ) for i in _PMs.ids(pm, nw, :bus))
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :vm, _PMs.ids(pm, nw, :bus), vm)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :vm, _PMs.ids(pm, nw, :bus), vm)
 
 end
 
@@ -815,7 +815,7 @@ function variable_mc_generation_active(pm::_PMs.AbstractPowerModel; nw::Int=pm.c
 
     _PMs.var(pm, nw)[:pg_bus] = Dict{Int, Any}()
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :pg, _PMs.ids(pm, nw, :gen), pg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :pg, _PMs.ids(pm, nw, :gen), pg)
 end
 
 
@@ -842,7 +842,7 @@ function variable_mc_generation_reactive(pm::_PMs.AbstractPowerModel; nw::Int=pm
 
     _PMs.var(pm, nw)[:qg_bus] = Dict{Int, Any}()
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :qg, _PMs.ids(pm, nw, :gen), qg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :qg, _PMs.ids(pm, nw, :gen), qg)
 end
 
 
@@ -866,7 +866,7 @@ function variable_mc_generation_current_real(pm::_PMs.AbstractPowerModel; nw::In
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :crg, _PMs.ids(pm, nw, :gen), crg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :crg, _PMs.ids(pm, nw, :gen), crg)
 end
 
 "variable: `cig[j]` for `j` in `gen`"
@@ -889,7 +889,7 @@ function variable_mc_generation_current_imaginary(pm::_PMs.AbstractPowerModel; n
         end
     end
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :cig, _PMs.ids(pm, nw, :gen), cig)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :cig, _PMs.ids(pm, nw, :gen), cig)
 end
 
 
@@ -910,7 +910,7 @@ function variable_mc_active_generation_on_off(pm::_PMs.AbstractPowerModel; nw::I
         start = comp_start_value(_PMs.ref(pm, nw, :gen, i), "pg_start", cnd, 0.0)
     ) for i in _PMs.ids(pm, nw, :gen))
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :pg, _PMs.ids(pm, nw, :gen), pg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :pg, _PMs.ids(pm, nw, :gen), pg)
 end
 
 
@@ -925,5 +925,5 @@ function variable_mc_reactive_generation_on_off(pm::_PMs.AbstractPowerModel; nw:
         start = comp_start_value(_PMs.ref(pm, nw, :gen, i), "qg_start", cnd, 0.0)
     ) for i in _PMs.ids(pm, nw, :gen))
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :qg, _PMs.ids(pm, nw, :gen), qg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :qg, _PMs.ids(pm, nw, :gen), qg)
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -114,7 +114,7 @@ function constraint_mc_power_balance_slack(pm::_PMs.AbstractACPModel, nw::Int, i
 
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -180,7 +180,7 @@ function constraint_mc_power_balance_shed(pm::_PMs.AbstractACPModel, nw::Int, i:
 
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -248,7 +248,7 @@ function constraint_mc_power_balance(pm::_PMs.AbstractACPModel, nw::Int, i::Int,
         push!(cstr_q, cq)
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -317,7 +317,7 @@ function constraint_mc_power_balance_load(pm::_PMs.AbstractACPModel, nw::Int, i:
         push!(cstr_q, cq)
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -144,7 +144,7 @@ function constraint_mc_power_balance_slack(pm::_PMs.AbstractACRModel, nw::Int, i
         push!(cstr_q, cq)
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -196,7 +196,7 @@ function constraint_mc_power_balance(pm::_PMs.AbstractACRModel, nw::Int, i::Int,
         - (-vr.*(Gt*vi+Bt*vr) + vi.*(Gt*vr-Bt*vi))
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -262,7 +262,7 @@ function constraint_mc_power_balance_load(pm::_PMs.AbstractACRModel, nw::Int, i:
         push!(cstr_q, cq)
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -90,7 +90,7 @@ function constraint_mc_power_balance_load(pm::_PMs.AbstractActivePowerModel, nw:
     cnds = _PMs.conductor_ids(pm, nw)
     ncnds = length(cnds)
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = [NaN for i in 1:ncnds]
     end
@@ -181,7 +181,7 @@ function constraint_mc_thermal_limit_from(pm::_PMs.AbstractActivePowerModel, n::
         end
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, n, :branch, f_idx[1])[:mu_sm_fr] = mu_sm_fr
     end
 end
@@ -205,7 +205,7 @@ function constraint_mc_thermal_limit_to(pm::_PMs.AbstractActivePowerModel, n::In
         end
     end
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, n, :branch, t_idx[1])[:mu_sm_to] = mu_sm_to
     end
 end

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -35,8 +35,8 @@ function variable_mc_voltage_prod_hermitian(pm::AbstractUBFModels; n_cond::Int=3
     # maintain compatibility
     _PMs.var(pm, nw)[:w] = Dict{Int, Any}([(id, diag(Wr[id])) for id in bus_ids])
 
-    report && _PMs.sol_component_value(pm, nw, :bus, :Wr, _PMs.ids(pm, nw, :bus), Wr)
-    report && _PMs.sol_component_value(pm, nw, :bus, :Wi, _PMs.ids(pm, nw, :bus), Wi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :Wr, _PMs.ids(pm, nw, :bus), Wr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :bus, :Wi, _PMs.ids(pm, nw, :bus), Wi)
 end
 
 
@@ -69,8 +69,8 @@ function variable_mc_branch_series_current_prod_hermitian(pm::AbstractUBFModels;
     _PMs.var(pm, nw)[:CCi] = Li
     _PMs.var(pm, nw)[:cm] = Dict([(id, diag(Lr[id])) for id in branch_ids])
 
-    report && _PMs.sol_component_value(pm, nw, :branch, :CCr, _PMs.ids(pm, nw, :branch), Lr)
-    report && _PMs.sol_component_value(pm, nw, :branch, :CCi, _PMs.ids(pm, nw, :branch), Li)
+    report && InfrastructureModels.sol_component_value(pm, nw, :branch, :CCr, _PMs.ids(pm, nw, :branch), Lr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :branch, :CCi, _PMs.ids(pm, nw, :branch), Li)
 end
 
 
@@ -114,8 +114,8 @@ function variable_mc_branch_flow(pm::AbstractUBFModels; n_cond::Int=3, nw::Int=p
     _PMs.var(pm, nw)[:p] = Dict([(id,diag(P[id])) for id in branch_arcs])
     _PMs.var(pm, nw)[:q] = Dict([(id,diag(Q[id])) for id in branch_arcs])
 
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :Pf, :Pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), P)
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :Qf, :Qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), Q)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :Pf, :Pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), P)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :Qf, :Qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), Q)
 end
 
 
@@ -236,8 +236,8 @@ function variable_mc_generation_power(pm::SDPUBFKCLMXModel; nw::Int=pm.cnw, boun
     _PMs.var(pm, nw)[:pg] = Dict{Int, Any}([(id, diag(Pg[id])) for id in gen_ids])
     _PMs.var(pm, nw)[:qg] = Dict{Int, Any}([(id, diag(Qg[id])) for id in gen_ids])
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :Pg, _PMs.ids(pm, nw, :gen), Pg)
-    report && _PMs.sol_component_value(pm, nw, :gen, :Qg, _PMs.ids(pm, nw, :gen), Qg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :Pg, _PMs.ids(pm, nw, :gen), Pg)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :Qg, _PMs.ids(pm, nw, :gen), Qg)
 end
 
 
@@ -263,8 +263,8 @@ function variable_mc_generation_current(pm::AbstractUBFModels; nw::Int=pm.cnw, b
     _PMs.var(pm, nw)[:CCgr] = CCgr
     _PMs.var(pm, nw)[:CCgi] = CCgi
 
-    report && _PMs.sol_component_value(pm, nw, :gen, :CCgr, _PMs.ids(pm, nw, :gen), CCgr)
-    report && _PMs.sol_component_value(pm, nw, :gen, :CCgi, _PMs.ids(pm, nw, :gen), CCgi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :CCgr, _PMs.ids(pm, nw, :gen), CCgr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :gen, :CCgi, _PMs.ids(pm, nw, :gen), CCgi)
 end
 
 
@@ -366,8 +366,8 @@ function variable_mc_load_power(pm::AbstractUBFModels, load_ids::Array{Int,1}; n
         _PMs.var(pm, nw)[:ql][i] = ql[i]
     end
 
-    report && _PMs.sol_component_value(pm, nw, :load, :pl, load_ids, pl)
-    report && _PMs.sol_component_value(pm, nw, :load, :ql, load_ids, ql)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :pl, load_ids, pl)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :ql, load_ids, ql)
 end
 
 
@@ -396,8 +396,8 @@ function variable_mc_load_power_bus(pm::SDPUBFKCLMXModel, load_ids::Array{Int,1}
         _PMs.var(pm, nw, :Qd)[id] = Qd[id]
     end
 
-    report && _PMs.sol_component_value(pm, nw, :load, :Pd, load_ids, Pd)
-    report && _PMs.sol_component_value(pm, nw, :load, :Qd, load_ids, Qd)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :Pd, load_ids, Pd)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :Qd, load_ids, Qd)
 end
 
 
@@ -437,8 +437,8 @@ function variable_mc_load_delta_aux(pm::AbstractUBFModels, load_ids::Array{Int,1
     _PMs.var(pm, nw)[:Xdr] = Xdr
     _PMs.var(pm, nw)[:Xdi] = Xdi
 
-    report && _PMs.sol_component_value(pm, nw, :load, :Xdr, load_ids, Xdr)
-    report && _PMs.sol_component_value(pm, nw, :load, :Xdi, load_ids, Xdi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :Xdr, load_ids, Xdr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :Xdi, load_ids, Xdi)
 end
 
 
@@ -466,8 +466,8 @@ function variable_mc_load_current(pm::AbstractUBFModels, load_ids::Array{Int,1};
     _PMs.var(pm, nw)[:CCdr] = CCdr
     _PMs.var(pm, nw)[:CCdi] = CCdi
 
-    report && _PMs.sol_component_value(pm, nw, :load, :CCdr, load_ids, CCdr)
-    report && _PMs.sol_component_value(pm, nw, :load, :CCdi, load_ids, CCdi)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :CCdr, load_ids, CCdr)
+    report && InfrastructureModels.sol_component_value(pm, nw, :load, :CCdi, load_ids, CCdi)
 end
 
 
@@ -810,7 +810,7 @@ function constraint_mc_power_balance(pm::KCLMXModels, n::Int, i::Int, bus_arcs, 
     # _PMs.con(pm, n, :kcl_Q)[i] =
     cq = JuMP.@constraint(pm.model, sum(Qg[g] for g in bus_gens) .== sum(Q[a] for a in bus_arcs) + sum(Qd[d] for d in bus_loads) + (-Wr*Bt'+Wi*Gt'))
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, n, :bus, i)[:lam_kcl_r] = cp
         _PMs.sol(pm, n, :bus, i)[:lam_kcl_i] = cq
     end

--- a/src/form/bf_mx_lin.jl
+++ b/src/form/bf_mx_lin.jl
@@ -115,7 +115,7 @@ function constraint_mc_power_balance(pm::LPUBFDiagModel, nw::Int, i, bus_arcs, b
         + sum(bs.*w for bs in values(bus_bs))
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -59,7 +59,7 @@ function constraint_mc_power_balance_shed(pm::_PMs.AbstractDCPModel, nw::Int, i:
         - sum(diag(gs)*1.0^2 .*z_shunt[n] for (n,gs) in bus_gs)
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cp
     end
 end

--- a/src/form/ivr.jl
+++ b/src/form/ivr.jl
@@ -29,8 +29,8 @@ function variable_mc_branch_current(pm::_PMs.AbstractIVRModel; nw::Int=pm.cnw, b
 
     _PMs.var(pm, nw)[:p] = p
     _PMs.var(pm, nw)[:q] = q
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :pf, :pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), p)
-    report && _PMs.sol_component_value_edge(pm, nw, :branch, :qf, :qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), q)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :pf, :pt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), p)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :branch, :qf, :qt, _PMs.ref(pm, nw, :arcs_from), _PMs.ref(pm, nw, :arcs_to), q)
 
     variable_mc_branch_series_current_real(pm, nw=nw, bounded=bounded, report=report; kwargs...)
     variable_mc_branch_series_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
@@ -67,8 +67,8 @@ function variable_mc_transformer_current(pm::_PMs.AbstractIVRModel; nw::Int=pm.c
 
     _PMs.var(pm, nw)[:p] = p
     _PMs.var(pm, nw)[:q] = q
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :pf, :pt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), p)
-    report && _PMs.sol_component_value_edge(pm, nw, :transformer, :qf, :qt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), q)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :pf, :pt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), p)
+    report && InfrastructureModels.sol_component_value_edge(pm, nw, :transformer, :qf, :qt, _PMs.ref(pm, nw, :arcs_from_trans), _PMs.ref(pm, nw, :arcs_to_trans), q)
 end
 
 
@@ -411,7 +411,7 @@ function objective_variable_pg_cost(pm::_PMs.AbstractIVRModel; report::Bool=true
         pg_cost = _PMs.var(pm, n)[:pg_cost] = JuMP.@variable(pm.model,
             [i in _PMs.ids(pm, n, :gen)], base_name="$(n)_pg_cost",
         )
-        report && _PMs.sol_component_value(pm, n, :gen, :pg_cost, _PMs.ids(pm, n, :gen), pg_cost)
+        report && InfrastructureModels.sol_component_value(pm, n, :gen, :pg_cost, _PMs.ids(pm, n, :gen), pg_cost)
 
         nc = length(conductor_ids(pm, n))
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -49,7 +49,7 @@ function constraint_mc_power_balance_slack(pm::_PMs.AbstractWModels, nw::Int, i,
         + q_slack
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -125,7 +125,7 @@ function constraint_mc_power_balance_shed(pm::_PMs.AbstractWModels, nw::Int, i, 
         - sum(z_shunt[n].*(-w.*diag(Bt')) for (n,Gs,Bs) in bus_GsBs)
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
@@ -178,7 +178,7 @@ function constraint_mc_power_balance_load(pm::_PMs.AbstractWModels, nw::Int, i, 
         - diag(-Wr*Bt'+Wi*Gt')
     )
 
-    if _PMs.report_duals(pm)
+    if InfrastructureModels.report_duals(pm)
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         _PMs.sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end

--- a/test/delta_gens.jl
+++ b/test/delta_gens.jl
@@ -35,11 +35,11 @@
                 [PMs.ACPPowerModel, PMs.ACRPowerModel, PMs.IVRPowerModel],
                 [PMD.build_mc_opf, PMD.build_mc_opf, PMD.build_mc_opf_iv]
             )
-            pm_1  = PMs.instantiate_model(pmd_1, form, build_method, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+            pm_1  = PMs.instantiate_model(pmd_1, form, build_method, ref_extensions=[PMD.ref_add_arcs_trans!])
             sol_1 = PMs.optimize_model!(pm_1, optimizer=ipopt_solver)
             @assert(sol_1["termination_status"]==LOCALLY_SOLVED)
 
-            pm_2  = PMs.instantiate_model(pmd_2, form, build_method, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+            pm_2  = PMs.instantiate_model(pmd_2, form, build_method, ref_extensions=[PMD.ref_add_arcs_trans!])
             sol_2 = PMs.optimize_model!(pm_2, optimizer=ipopt_solver)
             @assert(sol_2["termination_status"]==LOCALLY_SOLVED)
 
@@ -77,11 +77,11 @@
     #         gen["model"] = 2
     #     end
     #
-    #     pm_ivr  = PMs.instantiate_model(pmd, PMs.IVRPowerModel, PMD.build_mc_opf_iv, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+    #     pm_ivr  = PMs.instantiate_model(pmd, PMs.IVRPowerModel, PMD.build_mc_opf_iv, ref_extensions=[PMD.ref_add_arcs_trans!])
     #     sol_ivr = PMs.optimize_model!(pm_ivr, optimizer=ipopt_solver)
     #     @assert(sol_1["termination_status"]==LOCALLY_SOLVED)
     #
-    #     pm_acr  = PMs.instantiate_model(pmd, PMs.ACRPowerModel, PMD.build_mc_opf, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+    #     pm_acr  = PMs.instantiate_model(pmd, PMs.ACRPowerModel, PMD.build_mc_opf, ref_extensions=[PMD.ref_add_arcs_trans!])
     #     sol_acr = PMs.optimize_model!(pm_acr, optimizer=ipopt_solver)
     #     @assert(sol_2["termination_status"]==LOCALLY_SOLVED)
     #

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -3,7 +3,7 @@
 @testset "test loadmodels pf" begin
     @testset "loadmodels connection variations" begin
         pmd = PMD.parse_file("../test/data/opendss/case3_lm_1230.dss")
-        pm = PMs.instantiate_model(pmd, PMs.ACPPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+        pm = PMs.instantiate_model(pmd, PMs.ACPPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!])
         sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
         # voltage magnitude at load bus
         @test isapprox(vm(sol, pmd, "loadbus"), [0.999993, 0.999992, 0.999993], atol=1E-5)
@@ -50,7 +50,7 @@
     end
     @testset "loadmodels 1/2/5 in acp pf" begin
         pmd = PMD.parse_file("../test/data/opendss/case3_lm_models.dss")
-        pm = PMs.instantiate_model(pmd, PMs.ACPPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+        pm = PMs.instantiate_model(pmd, PMs.ACPPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!])
         sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
         # voltage magnitude at load bus
         @test isapprox(vm(sol, pmd, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)
@@ -84,7 +84,7 @@
     end
     @testset "loadmodels 1/2/5 in acr pf" begin
         pmd = PMD.parse_file("../test/data/opendss/case3_lm_models.dss")
-        pm = PMs.instantiate_model(pmd, PMs.ACRPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+        pm = PMs.instantiate_model(pmd, PMs.ACRPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!])
         sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
         # voltage magnitude at load bus
         @test isapprox(calc_vm_acr(sol, pmd, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)
@@ -118,7 +118,7 @@
     end
     @testset "loadmodels 1/2/5 in ivr pf" begin
         pmd = PMD.parse_file("../test/data/opendss/case3_lm_models.dss")
-        pm = PMs.instantiate_model(pmd, PMs.IVRPowerModel, PMD.build_mc_pf_iv, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+        pm = PMs.instantiate_model(pmd, PMs.IVRPowerModel, PMD.build_mc_pf_iv, ref_extensions=[PMD.ref_add_arcs_trans!])
         sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
         # voltage magnitude at load bus
         @test isapprox(calc_vm_acr(sol, pmd, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -164,7 +164,7 @@
 
         @testset "matrix branch shunts acr pf" begin
             data_pmd = PMD.parse_file("../test/data/opendss/case_mxshunt.dss")
-            pm = PMs.instantiate_model(data_pmd, PMs.ACRPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+            pm = PMs.instantiate_model(data_pmd, PMs.ACRPowerModel, PMD.build_mc_pf, ref_extensions=[PMD.ref_add_arcs_trans!])
             sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
 
             calc_vm(id) = sqrt.(sol["solution"]["bus"][id]["vr"].^2+sol["solution"]["bus"][id]["vi"].^2)

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -116,7 +116,7 @@
             # free the taps
             pmd_data["transformer"]["1"]["fixed"] = zeros(Bool, 3)
             pmd_data["transformer"]["2"]["fixed"] = zeros(Bool, 3)
-            pm = PMs.instantiate_model(pmd_data, PMs.ACPPowerModel, PMD.build_mc_opf_oltc, ref_extensions=[PMD.ref_add_arcs_trans!], multiconductor=true)
+            pm = PMs.instantiate_model(pmd_data, PMs.ACPPowerModel, PMD.build_mc_opf_oltc, ref_extensions=[PMD.ref_add_arcs_trans!])
             sol = PMs.optimize_model!(pm, optimizer=ipopt_solver)
             # check that taps are set as to boost the voltage in the branches as much as possible;
             # this is trivially optimal if the voltage bounds are not binding


### PR DESCRIPTION
@pseudocubic and @sanderclaeys these are the revisions that are required for PM v0.16.  Given that you will need to bump your minor version to v0.9, you might want to wait a week to see if PM v0.17 comes out (a function rename update) and put both updates into one release.

Also, in this PR I did not update to the convention of `const _PM = PowerModels` and `const _IM = InfrastructureModels`, but we might consider doing that update in the next release as well.