### PR TITLE
ADD: Store references for power balance constraints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## staged
 
-- none
+- Store references for power balance constraints.
 
 ## v0.9.0
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -22,6 +22,14 @@ function constraint_mc_slack_power_balance(pm::_PM.AbstractPowerModel, i::Int; n
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
 
+    if !haskey(con(pm, nw), :lam_kcl_r)
+        con(pm, nw)[:lam_kcl_r] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
+    if !haskey(con(pm, nw), :lam_kcl_i)
+        con(pm, nw)[:lam_kcl_i] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
     constraint_mc_slack_power_balance(pm, nw, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
@@ -172,6 +180,14 @@ function constraint_mc_power_balance(pm::_PM.AbstractPowerModel, i::Int; nw::Int
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
 
+    if !haskey(con(pm, nw), :lam_kcl_r)
+        con(pm, nw)[:lam_kcl_r] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
+    if !haskey(con(pm, nw), :lam_kcl_i)
+        con(pm, nw)[:lam_kcl_i] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
     constraint_mc_power_balance(pm, nw, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
 end
 
@@ -230,6 +246,14 @@ function constraint_mc_load_power_balance(pm::_PM.AbstractPowerModel, i::Int; nw
 
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
+
+    if !haskey(con(pm, nw), :lam_kcl_r)
+        con(pm, nw)[:lam_kcl_r] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
+    if !haskey(con(pm, nw), :lam_kcl_i)
+        con(pm, nw)[:lam_kcl_i] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
 
     constraint_mc_load_power_balance(pm, nw, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
 end
@@ -331,6 +355,14 @@ function constraint_mc_shed_power_balance(pm::_PM.AbstractPowerModel, i::Int; nw
 
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
+
+    if !haskey(con(pm, nw), :lam_kcl_r)
+        con(pm, nw)[:lam_kcl_r] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
+
+    if !haskey(con(pm, nw), :lam_kcl_i)
+        con(pm, nw)[:lam_kcl_i] = Dict{Int,Array{JuMP.ConstraintRef}}()
+    end
 
     constraint_mc_shed_power_balance(pm, nw, i, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -114,6 +114,9 @@ function constraint_mc_slack_power_balance(pm::_PM.AbstractACPModel, nw::Int, i:
 
     end
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
@@ -186,6 +189,9 @@ function constraint_mc_shed_power_balance(pm::_PM.AbstractACPModel, nw::Int, i::
 
     end
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
@@ -253,6 +259,9 @@ function constraint_mc_power_balance(pm::_PM.AbstractACPModel, nw::Int, i::Int, 
         )
         push!(cstr_q, cq)
     end
+
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
 
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
@@ -322,6 +331,9 @@ function constraint_mc_load_power_balance(pm::_PM.AbstractACPModel, nw::Int, i::
         )
         push!(cstr_q, cq)
     end
+
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
 
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -145,6 +145,9 @@ function constraint_mc_slack_power_balance(pm::_PM.AbstractACRModel, nw::Int, i:
         push!(cstr_q, cq)
     end
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
@@ -196,6 +199,9 @@ function constraint_mc_power_balance(pm::_PM.AbstractACRModel, nw::Int, i::Int, 
         # shunt
         - (-vr.*(Gt*vi+Bt*vr) + vi.*(Gt*vr-Bt*vi))
     )
+
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
 
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
@@ -262,6 +268,9 @@ function constraint_mc_load_power_balance(pm::_PM.AbstractACRModel, nw::Int, i::
         )
         push!(cstr_q, cq)
     end
+
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
 
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -90,6 +90,9 @@ function constraint_mc_load_power_balance(pm::_PM.AbstractActivePowerModel, nw::
     cnds = conductor_ids(pm, nw)
     ncnds = length(cnds)
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = []
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = [NaN for i in 1:ncnds]

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -827,18 +827,18 @@ S = U.I' = U.(Y.U)' = U.U'.Y' = W.Y'
 P =  Wr.G'+Wi.B'
 Q = -Wr.B'+Wi.G'
 """
-function constraint_mc_load_power_balance(pm::KCLMXModels, n::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
-    Wr = var(pm, n, :Wr, i)
-    Wi = var(pm, n, :Wi, i)
+function constraint_mc_load_power_balance(pm::KCLMXModels, nw::Int, i::Int, bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_gs, bus_bs)
+    Wr = var(pm, nw, :Wr, i)
+    Wi = var(pm, nw, :Wi, i)
 
-    P = get(var(pm, n), :P, Dict()); _PM._check_var_keys(P, bus_arcs, "active power", "branch")
-    Q = get(var(pm, n), :Q, Dict()); _PM._check_var_keys(Q, bus_arcs, "reactive power", "branch")
-    Pg = get(var(pm, n), :Pg_bus, Dict()); _PM._check_var_keys(Pg, bus_gens, "active power", "generator")
-    Qg = get(var(pm, n), :Qg_bus, Dict()); _PM._check_var_keys(Qg, bus_gens, "reactive power", "generator")
-    Pd = get(var(pm, n), :Pd_bus, Dict()); _PM._check_var_keys(Pd, bus_loads, "active power", "load")
-    Qd = get(var(pm, n), :Qd_bus, Dict()); _PM._check_var_keys(Qd, bus_loads, "reactive power", "load")
+    P = get(var(pm, nw), :P, Dict()); _PM._check_var_keys(P, bus_arcs, "active power", "branch")
+    Q = get(var(pm, nw), :Q, Dict()); _PM._check_var_keys(Q, bus_arcs, "reactive power", "branch")
+    Pg = get(var(pm, nw), :Pg_bus, Dict()); _PM._check_var_keys(Pg, bus_gens, "active power", "generator")
+    Qg = get(var(pm, nw), :Qg_bus, Dict()); _PM._check_var_keys(Qg, bus_gens, "reactive power", "generator")
+    Pd = get(var(pm, nw), :Pd_bus, Dict()); _PM._check_var_keys(Pd, bus_loads, "active power", "load")
+    Qd = get(var(pm, nw), :Qd_bus, Dict()); _PM._check_var_keys(Qd, bus_loads, "reactive power", "load")
 
-    cnds = conductor_ids(pm; nw=n)
+    cnds = conductor_ids(pm; nw=nw)
     ncnds = length(cnds)
 
     Gt = isempty(bus_gs) ? fill(0.0, ncnds, ncnds) : sum(values(bus_gs))
@@ -866,8 +866,11 @@ function constraint_mc_load_power_balance(pm::KCLMXModels, n::Int, i::Int, bus_a
         - diag(-Wr*Bt'+Wi*Gt')
     )
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
-        sol(pm, n, :bus, i)[:lam_kcl_r] = cstr_p
-        sol(pm, n, :bus, i)[:lam_kcl_i] = cstr_q
+        sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
+        sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
     end
 end

--- a/src/form/bf_mx_lin.jl
+++ b/src/form/bf_mx_lin.jl
@@ -117,6 +117,9 @@ function constraint_mc_load_power_balance(pm::LPUBFDiagModel, nw::Int, i, bus_ar
         + sum(bs.*w for bs in values(bus_bs))
     )
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -58,6 +58,9 @@ function constraint_mc_shed_power_balance(pm::_PM.AbstractDCPModel, nw::Int, i::
         - sum(diag(gs)*1.0^2 .*z_shunt[n] for (n,gs) in bus_gs)
     )
 
+    con(pm, nw, :lam_kcl_r)[i] = cp
+    con(pm, nw, :lam_kcl_i)[i] = []
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cp
     end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -51,6 +51,9 @@ function constraint_mc_slack_power_balance(pm::_PM.AbstractWModels, nw::Int, i, 
         + q_slack
     )
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
@@ -127,6 +130,9 @@ function constraint_mc_shed_power_balance(pm::_PM.AbstractWModels, nw::Int, i, b
         - sum(z_shunt[n].*(-w.*diag(Bt')) for (n,Gs,Bs) in bus_GsBs)
     )
 
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
+
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p
         sol(pm, nw, :bus, i)[:lam_kcl_i] = cstr_q
@@ -179,6 +185,9 @@ function constraint_mc_load_power_balance(pm::_PM.AbstractWModels, nw::Int, i, b
         - sum(qd[d] for d in bus_loads)
         - diag(-Wr*Bt'+Wi*Gt')
     )
+
+    con(pm, nw, :lam_kcl_r)[i] = cstr_p
+    con(pm, nw, :lam_kcl_i)[i] = cstr_q
 
     if _IM.report_duals(pm)
         sol(pm, nw, :bus, i)[:lam_kcl_r] = cstr_p


### PR DESCRIPTION
These additions store references of `:lam_kcl_r` and `:lam_kcl_i` into `con`.