### PR TITLE
FIX: Consistency of connections on `MATHEMATICAL` model components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)
 - Add CONTRIBUTING.md
 - Add pull request template
 - Add Pull Request Checks (Github Actions), to inform developers of potentially missing aspects of their PR

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,3 +8,4 @@ Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
 [compat]
 InfrastructureModels = "~0.5"
 PowerModels = "~0.17"
+Weave = "~0.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, PowerModelsDistribution
 import Weave
 
-Weave.set_chunk_defaults(Dict{Symbol, Any}(:line_width => 120))
+Weave.set_chunk_defaults!(Dict{Symbol, Any}(:line_width => 120))
 
 examples = []
 cd("examples")

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -749,39 +749,37 @@ function count_active_connections(data::Dict{String,<:Any})
 
     for edge_type in edge_elements
         for (_, component) in get(data, edge_type, Dict())
-            if (data_model == MATHEMATICAL && !startswith(component["name"], "_virtual")) || data_model == ENGINEERING
-                counted_connections = Set([])
-                if edge_type == "transformer" && !haskey(component, "f_connections") && data_model == ENGINEERING
-                    for (wdg, connections) in enumerate(component["connections"])
-                        for terminal in connections
-                            if !(terminal in counted_connections)
-                                if !(terminal in data["bus"][component["bus"][wdg]]["grounded"])
-                                    push!(counted_connections, terminal)
-                                    active_connections += 1
-                                end
+            counted_connections = Set([])
+            if edge_type == "transformer" && !haskey(component, "f_connections") && data_model == ENGINEERING
+                for (wdg, connections) in enumerate(component["connections"])
+                    for terminal in connections
+                        if !(terminal in counted_connections)
+                            if !(terminal in data["bus"][component["bus"][wdg]]["grounded"])
+                                push!(counted_connections, terminal)
+                                active_connections += 1
                             end
                         end
                     end
-                else
-                    for (bus, connections) in [(component["f_bus"], component["f_connections"]), (component["t_bus"], component["t_connections"])]
-                        for (i, terminal) in enumerate(connections)
-                            if !(terminal in counted_connections)
-                                if data_model == ENGINEERING
-                                    if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
-                                        push!(counted_connections, terminal)
-                                        active_connections += 1
-                                    elseif !(terminal in data["bus"][bus]["grounded"])
-                                        push!(counted_connections, terminal)
-                                        active_connections += 1
-                                    end
-                                else
-                                    if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
-                                        push!(counted_connections, terminal)
-                                        active_connections += 1
-                                    elseif !data["bus"]["$bus"]["grounded"][i]
-                                        push!(counted_connections, terminal)
-                                        active_connections += 1
-                                    end
+                end
+            else
+                for (bus, connections) in [(component["f_bus"], component["f_connections"]), (component["t_bus"], component["t_connections"])]
+                    for (i, terminal) in enumerate(connections)
+                        if !(terminal in counted_connections)
+                            if data_model == ENGINEERING
+                                if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
+                                    push!(counted_connections, terminal)
+                                    active_connections += 1
+                                elseif !(terminal in data["bus"][bus]["grounded"])
+                                    push!(counted_connections, terminal)
+                                    active_connections += 1
+                                end
+                            else
+                                if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
+                                    push!(counted_connections, terminal)
+                                    active_connections += 1
+                                elseif !data["bus"]["$bus"]["grounded"][i]
+                                    push!(counted_connections, terminal)
+                                    active_connections += 1
                                 end
                             end
                         end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -738,3 +738,88 @@ function _nan2zero(b, a; val=0)
     b[and.(isnan.(b), a.==val)] .= 0.0
     return b
 end
+
+
+"Counts active ungrounded connections on edge components"
+function count_active_connections(data::Dict{String,<:Any})
+    data_model = get(data, "data_model", MATHEMATICAL)
+    edge_elements = data_model == MATHEMATICAL ? PowerModelsDistribution._math_edge_elements : PowerModelsDistribution._eng_edge_elements
+    # bus_connections = Dict(id => [] for (id, _) in data["bus"])
+    active_connections = 0
+
+    for edge_type in edge_elements
+        for (_, component) in get(data, edge_type, Dict())
+            if (data_model == MATHEMATICAL && !startswith(component["name"], "_virtual")) || data_model == ENGINEERING
+                counted_connections = Set([])
+                if edge_type == "transformer" && !haskey(component, "f_connections") && data_model == ENGINEERING
+                    for (wdg, connections) in enumerate(component["connections"])
+                        for terminal in connections
+                            if !(terminal in counted_connections)
+                                if !(terminal in data["bus"][component["bus"][wdg]]["grounded"])
+                                    push!(counted_connections, terminal)
+                                    active_connections += 1
+                                end
+                            end
+                        end
+                    end
+                else
+                    for (bus, connections) in [(component["f_bus"], component["f_connections"]), (component["t_bus"], component["t_connections"])]
+                        for (i, terminal) in enumerate(connections)
+                            if !(terminal in counted_connections)
+                                if data_model == ENGINEERING
+                                    if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    elseif !(terminal in data["bus"][bus]["grounded"])
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    end
+                                else
+                                    if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    elseif !data["bus"]["$bus"]["grounded"][i]
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return active_connections
+end
+
+
+"Counts active ungrounded terminals on buses"
+function count_active_terminals(data::Dict{String,<:Any}; count_grounded::Bool=false)
+    data_model = get(data, "data_model", MATHEMATICAL)
+    active_terminal_count = 0
+    for (_,bus) in data["bus"]
+        counted_terminals = []
+        for (i, terminal) in enumerate(bus["terminals"])
+            if !(terminal in counted_terminals)
+                if count_grounded
+                    push!(counted_terminals, terminal)
+                    active_terminal_count += 1
+                else
+                    if data_model == ENGINEERING
+                        if !(terminal in bus["grounded"])
+                            push!(counted_terminals, terminal)
+                            active_terminal_count += 1
+                        end
+                    else
+                        if !bus["grounded"][i]
+                            push!(counted_terminals, terminal)
+                            active_terminal_count += 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return active_terminal_count
+end

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -760,7 +760,7 @@ function _map_eng2math_voltage_source!(data_math::Dict{String,<:Any}, data_eng::
                 "source_id" => "_virtual_branch.$(eng_obj["source_id"])",
                 "f_bus" => bus_obj["bus_i"],
                 "t_bus" => data_math["bus_lookup"][eng_obj["bus"]],
-                "f_connections" => eng_obj["connections"],
+                "f_connections" => collect(1:nconductors),
                 "t_connections" => eng_obj["connections"],
                 "angmin" => fill(-60.0, nconductors),
                 "angmax" => fill( 60.0, nconductors),

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -738,19 +738,17 @@ function _map_eng2math_voltage_source!(data_math::Dict{String,<:Any}, data_eng::
         map_to = "gen.$(math_obj["index"])"
 
         if !all(isapprox.(get(eng_obj, "rs", zeros(1, 1)), 0)) && !all(isapprox.(get(eng_obj, "xs", zeros(1, 1)), 0))
-            t_bus = deepcopy(data_math["bus"]["$(math_obj["gen_bus"])"])
-
             bus_obj = Dict{String,Any}(
                 "bus_i" => length(data_math["bus"])+1,
                 "index" => length(data_math["bus"])+1,
-                "terminals" => t_bus["terminals"],
-                "grounded" => t_bus["grounded"],
+                "terminals" => collect(1:nconductors+1),
+                "grounded" => [fill(false, nconductors)..., true],
                 "name" => "_virtual_bus.voltage_source.$name",
                 "bus_type" => 3,
-                "vm" => eng_obj["vm"],
-                "va" => eng_obj["va"],
-                "vmin" => eng_obj["vm"],
-                "vmax" => eng_obj["vm"],
+                "vm" => [eng_obj["vm"]..., 0.0],
+                "va" => [eng_obj["va"]..., 0.0],
+                "vmin" => [eng_obj["vm"]..., 0.0],
+                "vmax" => [eng_obj["vm"]..., 0.0]
             )
 
             math_obj["gen_bus"] = gen_bus = bus_obj["bus_i"]

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -457,7 +457,7 @@ function _map_eng2math_switch!(data_math::Dict{String,<:Any}, data_eng::Dict{<:A
                 # "f_bus" => bus_obj["bus_i"],  # TODO enable real switches
                 "f_bus" => data_math["bus_lookup"][eng_obj["f_bus"]],
                 "t_bus" => data_math["bus_lookup"][eng_obj["t_bus"]],
-                "f_connections" => eng_obj["t_connections"],  # the virtual branch connects to the switch on the to-side
+                "f_connections" => eng_obj["f_connections"],  # TODO, change to t_connections, the virtual branch connects to the switch on the to-side
                 "t_connections" => eng_obj["t_connections"],  # should be identical to the switch's to-side connections
                 "br_r" => _impedance_conversion(data_eng, eng_obj, "rs"),
                 "br_x" => _impedance_conversion(data_eng, eng_obj, "xs"),

--- a/test/data.jl
+++ b/test/data.jl
@@ -87,13 +87,15 @@ end
     eng = parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
     math = transform_data_model(eng)
 
+    n_phases = 3
+
     eng_term_count = count_active_terminals(eng)
     eng_conn_count = count_active_connections(eng)
 
-    @test eng_term_count == 12 && eng_conn_count == 9
+    @test eng_term_count == length(eng["bus"]) * n_phases && eng_conn_count == (length(eng["transformer"]) + length(eng["line"])) * n_phases
 
     math_term_count = count_active_terminals(math)
     math_conn_count = count_active_connections(math)
 
-    @test math_term_count - math_conn_count == eng_term_count - eng_conn_count
+    @test math_term_count == length(math["bus"]) * n_phases && math_conn_count == (length(math["transformer"]) + length(math["branch"])) * n_phases
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -82,3 +82,18 @@ end
         @test count_nodes(dss) == 12  # stopped excluding source from node count
     end
 end
+
+@testset "test active conductor counting functions" begin
+    eng = parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
+    math = transform_data_model(eng)
+
+    eng_term_count = count_active_terminals(eng)
+    eng_conn_count = count_active_connections(eng)
+
+    @test eng_term_count == 12 && eng_conn_count == 9
+
+    math_term_count = count_active_terminals(math)
+    math_conn_count = count_active_connections(math)
+
+    @test math_term_count - math_conn_count == eng_term_count - eng_conn_count
+end


### PR DESCRIPTION
Currently, the connections/terminals lists that appear on virtual components that are
constructed in the conversion from the ENGINEERING to the MATHEMATICAL data model 
are not consistent, as they haven't yet been actively used.

This PR fixes this consistency issues for the terminals/grounding on virtual buses and connections, _i.e._ `f_connections` and `t_connections`, on virtual branches, consistent for all components that create them (`switch`, `transformer`, and `voltage_source`, currently).

This PR also adds two helper functions to aid in counting the number of active
un-grounded terminals on buses and active un-grounded connections on edge 
components to aid in the evaluation of whether a network is radial:

- `count_active_terminals`
- `count_active_connections`

Both added functions work on both `ENGINEERING` and `MATHEMATICAL` data models.