### PR TITLE
REF: Depreciate run_mc_mld_bf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Depreciate run_mc_mld_bf in favor of run_mc_mld (to be removed in v0.10)
 - Add CONTRIBUTING.md
 - Add pull request template
 - Add Pull Request Checks (Github Actions), to inform developers of potentially missing aspects of their PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## staged
 
-- Depreciate run_mc_mld_bf in favor of run_mc_mld (to be removed in v0.10)
+- Add functionality of run_mc_mld_bf to run_mc_mld via multiple dispatch
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)
 - Add CONTRIBUTING.md
 - Add pull request template

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -6,6 +6,7 @@ end
 
 "Run Branch Flow Model Load Shedding Problem"
 function run_mc_mld_bf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    Memento.warn(_LOGGER, "DEPRECIATED: run_mc_mld_bf is depreciated in favor of run_mc_mld, and will be removed in v0.10")
     return run_mc_model(data, model_type, solver, build_mc_mld_bf; kwargs...)
 end
 
@@ -74,7 +75,57 @@ end
 
 
 "Load shedding problem for Branch Flow model"
+function build_mc_mld(pm::AbstractUBFModels)
+    variable_mc_bus_voltage_indicator(pm; relax=true)
+    variable_mc_bus_voltage_on_off(pm)
+
+    variable_mc_branch_current(pm)
+    variable_mc_branch_power(pm)
+    variable_mc_transformer_power(pm)
+
+    variable_mc_gen_indicator(pm; relax=true)
+    variable_mc_gen_power_setpoint_on_off(pm)
+
+    variable_mc_load_indicator(pm; relax=true)
+    variable_mc_shunt_indicator(pm; relax=true)
+
+    constraint_mc_model_current(pm)
+
+    for i in ids(pm, :ref_buses)
+        constraint_mc_theta_ref(pm, i)
+    end
+
+    constraint_mc_bus_voltage_on_off(pm)
+
+    for i in ids(pm, :gen)
+        constraint_mc_gen_power_on_off(pm, i)
+    end
+
+    for i in ids(pm, :bus)
+        constraint_mc_shed_power_balance(pm, i)
+    end
+
+    for i in ids(pm, :branch)
+        constraint_mc_power_losses(pm, i)
+        constraint_mc_model_voltage_magnitude_difference(pm, i)
+
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
+    end
+
+    for i in ids(pm, :transformer)
+        constraint_mc_transformer_power(pm, i)
+    end
+
+    objective_mc_min_load_setpoint_delta(pm)
+end
+
+
+"Load shedding problem for Branch Flow model"
 function build_mc_mld_bf(pm::_PM.AbstractPowerModel)
+    # TODO remove for v0.10 (depreciated)
     variable_mc_bus_voltage_indicator(pm; relax=true)
     variable_mc_bus_voltage_on_off(pm)
 

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -6,7 +6,7 @@ end
 
 "Run Branch Flow Model Load Shedding Problem"
 function run_mc_mld_bf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    Memento.warn(_LOGGER, "DEPRECIATED: run_mc_mld_bf is depreciated in favor of run_mc_mld, and will be removed in v0.10")
+    Memento.info(_LOGGER, "We recommend using run_mc_mld, which will attempt to select appropriate variables and constraints based on the specified formulation, instead of run_mc_mld_bf")
     return run_mc_model(data, model_type, solver, build_mc_mld_bf; kwargs...)
 end
 
@@ -125,7 +125,6 @@ end
 
 "Load shedding problem for Branch Flow model"
 function build_mc_mld_bf(pm::_PM.AbstractPowerModel)
-    # TODO remove for v0.10 (depreciated)
     variable_mc_bus_voltage_indicator(pm; relax=true)
     variable_mc_bus_voltage_on_off(pm)
 

--- a/test/mld.jl
+++ b/test/mld.jl
@@ -90,7 +90,7 @@
 
         @test isapprox(result["solution"]["load"]["1"]["status"], 1.000; atol = 1e-3)
 
-        @test_throws(TESTLOG, MethodError, run_mc_mld(case5, NFAPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, MethodError, run_mc_mld_bf(case5, NFAPowerModel, ipopt_solver))
     end
 
     @testset "3-bus lpubfdiag mld" begin

--- a/test/mld.jl
+++ b/test/mld.jl
@@ -83,19 +83,19 @@
     end
 
     @testset "5-bus lpubfdiag mld" begin
-        result = run_mc_mld_bf(case5, LPUBFDiagPowerModel, ipopt_solver)
+        result = run_mc_mld(case5, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.1557; atol = 1e-4)
 
         @test isapprox(result["solution"]["load"]["1"]["status"], 1.000; atol = 1e-3)
 
-        @test_throws(TESTLOG, MethodError, run_mc_mld_bf(case5, NFAPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, MethodError, run_mc_mld(case5, NFAPowerModel, ipopt_solver))
     end
 
     @testset "3-bus lpubfdiag mld" begin
 
-        result = run_mc_mld_bf(case3_ml, LPUBFDiagPowerModel, ipopt_solver)
+        result = run_mc_mld(case3_ml, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 24.98; atol = 1e-1)
@@ -104,7 +104,7 @@
     end
 
     @testset "transformer case" begin
-        result = run_mc_mld_bf(ut_trans_2w_yy, LPUBFDiagPowerModel, ipopt_solver)
+        result = run_mc_mld(ut_trans_2w_yy, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1e-3)


### PR DESCRIPTION
Depreciates the `run_mc_mld_bf` function, as was done with the opf
branch flow variants in v0.9. This function was missed during that
refactor, so this PR will depreciate it as to make it a non-breaking
change, and we will plan to remove it in the next breaking release.