### PR TITLE
REF: extract kron reduction, phase projection from eng2math

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: .github/scripts/file-changed-check "${{ github.head_ref }}" "${{ github.base_ref }}" "docs/[A-Za-z0-9_/]+\.md"
+      - run: .github/scripts/file-changed-check "${{ github.head_ref }}" "${{ github.base_ref }}" "docs/[A-Za-z0-9_/]+\.md|examples/[A-Za-z0-9_/]+\.ipynb"
   dependencies-unchanged:
     name: Dependencies unchanged
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## staged
 
+- Refactors Kron reduction and padding transformations out of eng2math into their own transformation functions (#287)
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)
+- Add a transformation remove_all_bounds! that removes all fields ending in _ub and _lb (#278)
+- Add missing connections for virtual generator at voltage source
+- Fix pu conversion bus voltage bounds and add parsing for vm_pair_lb and vm_pair_ub
 - Add CONTRIBUTING.md
 - Add pull request template
 - Add Pull Request Checks (Github Actions), to inform developers of potentially missing aspects of their PR
@@ -10,9 +14,6 @@
 
 ## v0.9.0
 
-- Add a transformation rm_bounds! that removes all fields ending in _ub and _lb
-- Add missing connections for virtual generator at voltage source
-- Fix pu conversion bus voltage bounds and add parsing for vm_pair_lb and vm_pair_ub
 - Add `instantiate_mc_model` to aid in building JuMP model from ENGINEERING data model
 - SDP and SOC relaxations were broken but are fixed again (unit tests added)
 - Remove `run_mc_opf_iv`, `run_mc_opf_bf`, `run_mc_opf_bf_lm`, `run_mc_pf_bf`, `run_mc_pf_iv`, these can be accessed by using the correct formulation with `run_mc_opf` and `run_mc_pf`

--- a/examples/engineering_model.ipynb
+++ b/examples/engineering_model.ipynb
@@ -817,7 +817,9 @@
    "source": [
     "## Engineering Model Transformations\n",
     "\n",
-    "One of the power things about the engineering model is that data transformations are much more simple. Here we illustrate two examples that are currently included in PowerModelsDistribution, but writing your own data transformation functions will be trivial, as we will show\n",
+    "One of the power things about the engineering model is that data transformations are much more simple. Here we illustrate two examples that are currently included in PowerModelsDistribution, but writing your own data transformation functions will be trivial, as we will show.\n",
+    "\n",
+    "__Note__: In v0.9, `apply_kron_reduction!` and `apply_phase_projection!` are applied by default, but can be disabled with the keyword arguments `kron_reduced=false` and `project_phases=false`, respectively in `parse_file` or `transform_data_model`.\n",
     "\n",
     "First, there are several objects that have loss models by default when parsing from dss files, such as voltage sources, transformers, and switches. To remove these loss models, therefore making these components lossless, we can use the included `make_lossess!` function. Here we use a basic 2-winding wye-wye connected transformer case from `test` to illustrate this"
    ]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -107,7 +107,11 @@ function count_nodes(data::Dict{String,<:Any})::Int
 
                 if all(!occursin(pattern, name) for pattern in [_excluded_count_busname_patterns...])
                     if data["data_model"] == MATHEMATICAL
-                        n_nodes += length(bus["terminals"][.!get(bus, "grounded", zeros(length(bus["terminals"])))])
+                        if get(data, "is_padded", false)
+                            n_nodes += count(i->i>0, get(bus, "vmax", []))
+                        else
+                            n_nodes += length(bus["terminals"][.!get(bus, "grounded", zeros(length(bus["terminals"])))])
+                        end
                     else
                         n_nodes += length([n for n in bus["terminals"] if !(n in get(bus, "grounded", []))])
                     end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -778,11 +778,13 @@ function count_active_connections(data::Dict{String,<:Any})
                                     active_connections += 1
                                 end
                             else
-                                if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
+                                if edge_type == "transformer"
+                                    if component["configuration"] == DELTA || (component["configuration"] == WYE && terminal != connections[end])
                                     push!(counted_connections, terminal)
                                     active_connections += 1
+                                    end
                                 elseif !get(data["bus"]["$bus"]["grounded"], i, false)
-                                    if get(data, "is_padded", false) && data["bus"]["$bus"]["vmax"][i] > 0
+                                    if get(data, "is_projected", false) && get(data["bus"]["$bus"]["vmax"], i, Inf) > 0
                                         push!(counted_connections, terminal)
                                         active_connections += 1
                                     else

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -782,7 +782,7 @@ function count_active_connections(data::Dict{String,<:Any})
                                     push!(counted_connections, terminal)
                                     active_connections += 1
                                 elseif !get(data["bus"]["$bus"]["grounded"], i, false)
-                                    if get(data, "is_padded", false) && bus["vmax"][i] > 0
+                                    if get(data, "is_padded", false) && data["bus"]["$bus"]["vmax"][i] > 0
                                         push!(counted_connections, terminal)
                                         active_connections += 1
                                     else

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -781,9 +781,14 @@ function count_active_connections(data::Dict{String,<:Any})
                                 if edge_type == "transformer" && component["configuration"] == WYE && terminal != connections[end]
                                     push!(counted_connections, terminal)
                                     active_connections += 1
-                                elseif !data["bus"]["$bus"]["grounded"][i]
-                                    push!(counted_connections, terminal)
-                                    active_connections += 1
+                                elseif !get(data["bus"]["$bus"]["grounded"], i, false)
+                                    if get(data, "is_padded", false) && bus["vmax"][i] > 0
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    else
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
+                                    end
                                 end
                             end
                         end
@@ -814,7 +819,7 @@ function count_active_terminals(data::Dict{String,<:Any}; count_grounded::Bool=f
                             active_terminal_count += 1
                         end
                     else
-                        if !bus["grounded"][i]
+                        if !get(bus["grounded"], i, false)
                             push!(counted_terminals, terminal)
                             active_terminal_count += 1
                         end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -107,7 +107,7 @@ function count_nodes(data::Dict{String,<:Any})::Int
 
                 if all(!occursin(pattern, name) for pattern in [_excluded_count_busname_patterns...])
                     if data["data_model"] == MATHEMATICAL
-                        if get(data, "is_padded", false)
+                        if get(data, "is_projected", false)
                             n_nodes += count(i->i>0, get(bus, "vmax", []))
                         else
                             n_nodes += length(bus["terminals"][.!get(bus, "grounded", zeros(length(bus["terminals"])))])
@@ -780,8 +780,8 @@ function count_active_connections(data::Dict{String,<:Any})
                             else
                                 if edge_type == "transformer"
                                     if component["configuration"] == DELTA || (component["configuration"] == WYE && terminal != connections[end])
-                                    push!(counted_connections, terminal)
-                                    active_connections += 1
+                                        push!(counted_connections, terminal)
+                                        active_connections += 1
                                     end
                                 elseif !get(data["bus"]["$bus"]["grounded"], i, false)
                                     if get(data, "is_projected", false) && get(data["bus"]["$bus"]["vmax"], i, Inf) > 0

--- a/src/data_model/components.jl
+++ b/src/data_model/components.jl
@@ -594,14 +594,14 @@ function create_voltage_source(bus, connections;
     kwargs...
         )::Dict{String,Any}
 
-    n_conductors = length(connections)
+    nphases = configuration == WYE ? length(connections) - 1 : length(connections)
 
     voltage_source = Dict{String,Any}(
         "bus" => bus,
         "connections" => connections,
         "configuration" => configuration,
-        "vm" => !ismissing(vm) ? vm : ones(n_conductors),
-        "va" => !ismissing(va) ? va : zeros(n_conductors),
+        "vm" => !ismissing(vm) ? vm : ones(nphases),
+        "va" => !ismissing(va) ? va : zeros(nphases),
         "status" => get(kwargs, :status, ENABLED),
     )
 

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -638,14 +638,16 @@ function _map_eng2math_voltage_source!(data_math::Dict{String,<:Any}, data_eng::
                 "grounded" => f_bus["grounded"],
                 "name" => "_virtual_bus.voltage_source.$name",
                 "bus_type" => 3,
-                "vm" => eng_obj["vm"],
-                "va" => eng_obj["va"],
-                "vmin" => get(eng_obj, "vm_lb", eng_obj["vm"]),
-                "vmax" => get(eng_obj, "vm_ub", eng_obj["vm"]),
+                "vm" => deepcopy(eng_obj["vm"]),
+                "va" => deepcopy(eng_obj["va"]),
+                "vmin" => deepcopy(get(eng_obj, "vm_lb", eng_obj["vm"])),
+                "vmax" => deepcopy(get(eng_obj, "vm_ub", eng_obj["vm"])),
             )
-            for t in eng_obj["connections"]
-                if t in data_eng["bus"][eng_obj["bus"]]["grounded"]
-                    bus_obj["vmax"] = Inf
+            for (i,t) in enumerate(eng_obj["connections"])
+                if data_math["bus"]["$(data_math["bus_lookup"][eng_obj["bus"]])"]["grounded"][i]
+                    bus_obj["vm"][i] = 0
+                    bus_obj["vmin"][i] = 0
+                    bus_obj["vmax"][i] = Inf
                 end
             end
 

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -217,9 +217,6 @@ function _map_eng2math_line!(data_math::Dict{String,<:Any}, data_eng::Dict{<:Any
         math_obj["shift"] = zeros(nphases)
         math_obj["tap"] = ones(nphases)
 
-        f_bus = data_eng["bus"][eng_obj["f_bus"]]
-        t_bus = data_eng["bus"][eng_obj["t_bus"]]
-
         math_obj["switch"] = false
 
         math_obj["br_status"] = Int(eng_obj["status"])

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -176,7 +176,7 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     if haskey(data_eng, "voltage_source")
         for (_,eng_obj) in data_eng["voltage_source"]
             filter = eng_obj["connections"] .!= kr_neutral
-            _apply_filter!(eng_obj, ["connections"], filter)
+            _apply_filter!(eng_obj, ["vm", "va", "vm_lb", "vm_ub", "rs", "xs", "connections"], filter)
         end
     end
 

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -188,7 +188,7 @@ end
 
 
 "pad matrices to max number of conductors"
-function apply_property_padding!(data_eng::Dict{String,<:Any})
+function apply_phase_projection!(data_eng::Dict{String,<:Any})
     all_conductors = _get_complete_conductor_set(data_eng)
 
     if haskey(data_eng, "bus")
@@ -324,5 +324,5 @@ function apply_property_padding!(data_eng::Dict{String,<:Any})
         end
     end
 
-    data_eng["is_padded"] = true
+    data_eng["is_projected"] = true
 end

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -188,7 +188,7 @@ end
 
 
 "pad matrices to max number of conductors"
-function pad_mc_properties!(data_eng::Dict{String,<:Any})
+function apply_property_padding!(data_eng::Dict{String,<:Any})
     all_conductors = _get_complete_conductor_set(data_eng)
 
     if haskey(data_eng, "bus")

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -63,3 +63,258 @@ function remove_all_bounds!(data_eng)
         end
     end
 end
+
+
+"kron reduction"
+function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Vector{Int},Vector{String}}=[1,2,3], kr_neutral::Union{Int,String}=4)
+    if haskey(data_eng, "bus")
+        for (_, eng_obj) in data_eng["bus"]
+            filter = eng_obj["terminals"] .!= kr_neutral
+            terminals_kr = eng_obj["terminals"][filter]
+
+            @assert all(t in kr_phases for t in terminals_kr) "bus $name has terminals $(eng_obj["terminals"]), outside of $kr_phases, cannot be kron reduced"
+
+            _apply_filter!(eng_obj, ["vm", "va", "vm_lb", "vm_ub"], filter)
+            eng_obj["terminals"] = terminals_kr
+
+            gr_filter = eng_obj["grounded"] .!= kr_neutral
+            _apply_filter!(eng_obj, ["grounded", "rg", "xg"], gr_filter)
+        end
+    end
+
+    if haskey(data_eng, "line")
+        for (_, eng_obj) in data_eng["line"]
+            @assert all(eng_obj["f_connections"].==eng_obj["t_connections"]) "Kron reduction is only supported if f_connections == t_connections"
+
+            _apply_linecode!(eng_obj, data_eng)
+
+            filter = _kron_reduce_branch!(eng_obj, ["rs", "xs"], ["g_fr", "b_fr", "g_to", "b_to"], eng_obj["f_connections"], kr_neutral)
+            _apply_filter!(eng_obj, ["vad_lb", "vad_ub", "cm_ub", "cm_ub_b", "cm_ub_c", "sm_ub", "sm_ub_b", "sm_ub_c", "f_connections", "t_connections"], filter)
+        end
+    end
+
+    if haskey(data_eng, "transformer")
+        for (id, eng_obj) in data_eng["transformer"]
+            _apply_xfmrcode!(eng_obj, data_eng)
+
+            if haskey(eng_obj, "f_connections")
+                @assert all(eng_obj["f_connections"].==eng_obj["t_connections"]) "Kron reduction is only supported if f_connections == t_connections"
+
+                if eng_obj["configuration"] == WYE
+                    filter = eng_obj["f_connections"] .!= kr_neutral
+                    _apply_filter!(eng_obj, ["f_connections", "t_connections"], filter)
+                end
+            else
+                for (w, connections) in enumerate(eng_obj["connections"])
+                    if eng_obj["configuration"][w] == WYE
+                        filter = connections .!= kr_neutral
+                        _apply_filter!(eng_obj, ["connections"], w, filter)
+                    end
+                end
+            end
+        end
+    end
+
+    if haskey(data_eng, "switch")
+        for (_, eng_obj) in data_eng["switch"]
+            @assert all(eng_obj["f_connections"].==eng_obj["t_connections"]) "Kron reduction is only supported if f_connections == t_connections"
+
+            _apply_linecode!(eng_obj, data_eng)
+
+            filter = _kron_reduce_branch!(eng_obj, Vector{String}([k for k in ["rs", "xs"] if haskey(eng_obj, k)]), Vector{String}([]), eng_obj["f_connections"], kr_neutral)
+            _apply_filter!(eng_obj, ["vad_lb", "vad_ub", "cm_ub", "cm_ub_b", "cm_ub_c", "sm_ub", "sm_ub_b", "sm_ub_c", "f_connections", "t_connections"], filter)
+        end
+    end
+
+    if haskey(data_eng, "shunt")
+        for (_, eng_obj) in data_eng["shunt"]
+            filter = _kron_reduce_branch!(eng_obj, Vector{String}([]), ["gs", "bs"], eng_obj["connections"], kr_neutral)
+            _apply_filter!(eng_obj, ["connections"], filter)
+        end
+    end
+
+    if haskey(data_eng, "load")
+        for (_, eng_obj) in data_eng["load"]
+            if eng_obj["configuration"]==WYE
+                @assert eng_obj["connections"][end] == kr_neutral "for wye-connected loads, to kron reduce the connections list should end with a neutral"
+
+                filter = eng_obj["connections"] .!= kr_neutral
+                _apply_filter!(eng_obj, ["connections"], filter)
+            end
+        end
+    end
+
+    if haskey(data_eng, "generator")
+        for (_, eng_obj) in data_eng["generator"]
+            if eng_obj["configuration"]==WYE
+                @assert eng_obj["connections"][end] == kr_neutral "for wye-connected generators, to kron reduce the connections list should end with a neutral"
+
+                filter = eng_obj["connections"] .!= kr_neutral
+                _apply_filter!(eng_obj, ["connections"], filter)
+            end
+        end
+    end
+
+    if haskey(data_eng, "solar")
+        for (_, eng_obj) in data_eng["solar"]
+            if eng_obj["configuration"]==WYE
+                @assert eng_obj["connections"][end] == kr_neutral "for wye-connected solar, to kron reduce the connections list should end with a neutral"
+
+                filter = eng_obj["connections"] .!= kr_neutral
+                _apply_filter!(eng_obj, ["connections"], filter)
+            end
+        end
+    end
+
+    if haskey(data_eng, "storage")
+        for (_, eng_obj) in data_eng["storage"]
+            filter = eng_obj["connections"] .!= kr_neutral
+            _apply_filter!(eng_obj, ["connections"], filter)
+        end
+    end
+
+    if haskey(data_eng, "voltage_source")
+        for (_, eng_obj) in data_eng["voltage_source"]
+            filter = eng_obj["connections"] .!= kr_neutral
+            _apply_filter!(eng_obj, ["connections"], filter)
+        end
+    end
+
+    delete!(data_eng, "linecode")  # kron reduction moves linecode properties directly to lines
+    delete!(data_eng, "xfmrcode")  # kron reduction moves xfmrcode properties directly to transformers
+end
+
+
+"pad matrices to max number of conductors"
+function pad_mc_properties!(data_eng::Dict{String,<:Any})
+    all_conductors = _get_complete_conductor_set(data_eng)
+
+    if haskey(data_eng, "bus")
+        for (_, eng_obj) in data_eng["bus"]
+            if !haskey(eng_obj, "vm_lb")
+                eng_obj["vm_lb"] = fill(0.0, length(eng_obj["terminals"]))
+            end
+
+            if !haskey(eng_obj, "vm_ub")
+                eng_obj["vm_ub"] = fill(Inf, length(eng_obj["terminals"]))
+            end
+
+            _pad_properties!(eng_obj, ["vm", "va", "vm_lb", "vm_ub"], eng_obj["terminals"], all_conductors)
+
+            eng_obj["terminals"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "line")
+        for (_, eng_obj) in data_eng["line"]
+            _apply_linecode!(eng_obj, data_eng)
+
+            _pad_properties!(eng_obj, ["rs", "xs", "g_fr", "g_to", "b_fr", "b_to"], eng_obj["f_connections"], all_conductors)
+            _pad_properties!(eng_obj, ["vad_lb"], eng_obj["f_connections"], all_conductors; pad_value=-60.0)
+            _pad_properties!(eng_obj, ["vad_ub"], eng_obj["f_connections"], all_conductors; pad_value=60.0)
+            for key in ["cm_ub", "cm_ub_b", "cm_ub_c", "sm_ub", "sm_ub_b", "sm_ub_c"]
+                if haskey(eng_obj, key)
+                    _pad_properties!(eng_obj, [key], eng_obj["f_connections"], all_conductors)
+                end
+            end
+
+            eng_obj["f_connections"] = eng_obj["t_connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "transformer")
+        for (id, eng_obj) in data_eng["transformer"]
+            _apply_xfmrcode!(eng_obj, data_eng)
+
+            if haskey(eng_obj, "f_connections")
+                _pad_properties!(eng_obj, ["tm_lb", "tm_ub", "tm_set"], eng_obj["f_connections"], all_conductors; pad_value=1.0)
+                _pad_properties!(eng_obj, ["tm_fix"], eng_obj["f_connections"], all_conductors; pad_value=false)
+
+                eng_obj["f_connections"] = eng_obj["t_connections"] = all_conductors
+            else
+                for (w, connections) in enumerate(eng_obj["connections"])
+                    _pad_properties!(eng_obj, ["tm_lb", "tm_ub", "tm_set"], w, connections, all_conductors; pad_value=1.0)
+                    _pad_properties!(eng_obj, ["tm_fix"], w, connections, all_conductors; pad_value=false)
+
+                    eng_obj["connections"][w] = all_conductors
+                end
+            end
+        end
+    end
+
+    if haskey(data_eng, "switch")
+        for (_, eng_obj) in data_eng["switch"]
+            _apply_linecode!(eng_obj, data_eng)
+
+            _pad_properties!(eng_obj, ["rs", "xs"], eng_obj["f_connections"], all_conductors)
+            _pad_properties!(eng_obj, ["vad_lb"], eng_obj["f_connections"], all_conductors; pad_value=-60.0)
+            _pad_properties!(eng_obj, ["vad_ub"], eng_obj["f_connections"], all_conductors; pad_value=60.0)
+            for key in ["cm_ub", "cm_ub_b", "cm_ub_c", "sm_ub", "sm_ub_b", "sm_ub_c"]
+                if haskey(eng_obj, key)
+                    _pad_properties!(eng_obj, [key], eng_obj["f_connections"], all_conductors)
+                end
+            end
+
+            eng_obj["f_connections"] = all_conductors
+            eng_obj["t_connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "shunt")
+        for (_, eng_obj) in data_eng["shunt"]
+            _pad_properties!(eng_obj, ["gs", "bs"], eng_obj["connections"], all_conductors)
+
+            eng_obj["connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "load")
+        for (_, eng_obj) in data_eng["load"]
+            if eng_obj["configuration"] == WYE
+                _pad_properties!(eng_obj, ["pd_nom", "qd_nom"], eng_obj["connections"], all_conductors)
+            else
+                _pad_properties_delta!(eng_obj, ["pd_nom", "qd_nom"], eng_obj["connections"], all_conductors)
+            end
+
+            eng_obj["connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "generator")
+        for (_, eng_obj) in data_eng["generator"]
+            if eng_obj["configuration"]==WYE
+                _pad_properties!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
+            else
+                _pad_properties_delta!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
+            end
+        end
+    end
+
+    if haskey(data_eng, "solar")
+        for (_, eng_obj) in data_eng["solar"]
+            if eng_obj["configuration"]==WYE
+                _pad_properties!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
+            else
+                _pad_properties_delta!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
+            end
+
+            eng_obj["connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "storage")
+        for (_, eng_obj) in data_eng["storage"]
+            _pad_properties!(eng_obj, ["cm_ub", "qs_lb", "qs_ub", "rs", "xs", "ps", "qs"], eng_obj["connections"], all_conductors)
+
+            eng_obj["connections"] = all_conductors
+        end
+    end
+
+    if haskey(data_eng, "voltage_source")
+        for (_, eng_obj) in data_eng["voltage_source"]
+            _pad_properties!(eng_obj, ["pg", "qg", "pg_lb", "pg_ub", "qg_lb", "qg_ub", "vm", "va"], eng_obj["connections"], all_conductors)
+
+            eng_obj["connections"] = all_conductors
+        end
+    end
+end

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -68,11 +68,11 @@ end
 "kron reduction"
 function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Vector{Int},Vector{String}}=[1,2,3], kr_neutral::Union{Int,String}=4)
     if haskey(data_eng, "bus")
-        for (_, eng_obj) in data_eng["bus"]
+        for (id,eng_obj) in data_eng["bus"]
             filter = eng_obj["terminals"] .!= kr_neutral
             terminals_kr = eng_obj["terminals"][filter]
 
-            @assert all(t in kr_phases for t in terminals_kr) "bus $name has terminals $(eng_obj["terminals"]), outside of $kr_phases, cannot be kron reduced"
+            @assert all(t in kr_phases for t in terminals_kr) "bus $id has terminals $(eng_obj["terminals"]), outside of $kr_phases, cannot be kron reduced"
 
             _apply_filter!(eng_obj, ["vm", "va", "vm_lb", "vm_ub"], filter)
             eng_obj["terminals"] = terminals_kr
@@ -83,7 +83,7 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "line")
-        for (_, eng_obj) in data_eng["line"]
+        for (_,eng_obj) in data_eng["line"]
             @assert all(eng_obj["f_connections"].==eng_obj["t_connections"]) "Kron reduction is only supported if f_connections == t_connections"
 
             _apply_linecode!(eng_obj, data_eng)
@@ -116,7 +116,7 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "switch")
-        for (_, eng_obj) in data_eng["switch"]
+        for (_,eng_obj) in data_eng["switch"]
             @assert all(eng_obj["f_connections"].==eng_obj["t_connections"]) "Kron reduction is only supported if f_connections == t_connections"
 
             _apply_linecode!(eng_obj, data_eng)
@@ -127,14 +127,14 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "shunt")
-        for (_, eng_obj) in data_eng["shunt"]
+        for (_,eng_obj) in data_eng["shunt"]
             filter = _kron_reduce_branch!(eng_obj, Vector{String}([]), ["gs", "bs"], eng_obj["connections"], kr_neutral)
             _apply_filter!(eng_obj, ["connections"], filter)
         end
     end
 
     if haskey(data_eng, "load")
-        for (_, eng_obj) in data_eng["load"]
+        for (_,eng_obj) in data_eng["load"]
             if eng_obj["configuration"]==WYE
                 @assert eng_obj["connections"][end] == kr_neutral "for wye-connected loads, to kron reduce the connections list should end with a neutral"
 
@@ -145,7 +145,7 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "generator")
-        for (_, eng_obj) in data_eng["generator"]
+        for (_,eng_obj) in data_eng["generator"]
             if eng_obj["configuration"]==WYE
                 @assert eng_obj["connections"][end] == kr_neutral "for wye-connected generators, to kron reduce the connections list should end with a neutral"
 
@@ -156,7 +156,7 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "solar")
-        for (_, eng_obj) in data_eng["solar"]
+        for (_,eng_obj) in data_eng["solar"]
             if eng_obj["configuration"]==WYE
                 @assert eng_obj["connections"][end] == kr_neutral "for wye-connected solar, to kron reduce the connections list should end with a neutral"
 
@@ -167,14 +167,14 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
     end
 
     if haskey(data_eng, "storage")
-        for (_, eng_obj) in data_eng["storage"]
+        for (_,eng_obj) in data_eng["storage"]
             filter = eng_obj["connections"] .!= kr_neutral
             _apply_filter!(eng_obj, ["connections"], filter)
         end
     end
 
     if haskey(data_eng, "voltage_source")
-        for (_, eng_obj) in data_eng["voltage_source"]
+        for (_,eng_obj) in data_eng["voltage_source"]
             filter = eng_obj["connections"] .!= kr_neutral
             _apply_filter!(eng_obj, ["connections"], filter)
         end
@@ -182,6 +182,8 @@ function apply_kron_reduction!(data_eng::Dict{String,<:Any}; kr_phases::Union{Ve
 
     delete!(data_eng, "linecode")  # kron reduction moves linecode properties directly to lines
     delete!(data_eng, "xfmrcode")  # kron reduction moves xfmrcode properties directly to transformers
+
+    data_eng["is_kron_reduced"] = true
 end
 
 
@@ -190,7 +192,7 @@ function pad_mc_properties!(data_eng::Dict{String,<:Any})
     all_conductors = _get_complete_conductor_set(data_eng)
 
     if haskey(data_eng, "bus")
-        for (_, eng_obj) in data_eng["bus"]
+        for (_,eng_obj) in data_eng["bus"]
             if !haskey(eng_obj, "vm_lb")
                 eng_obj["vm_lb"] = fill(0.0, length(eng_obj["terminals"]))
             end
@@ -201,12 +203,12 @@ function pad_mc_properties!(data_eng::Dict{String,<:Any})
 
             _pad_properties!(eng_obj, ["vm", "va", "vm_lb", "vm_ub"], eng_obj["terminals"], all_conductors)
 
-            eng_obj["terminals"] = all_conductors
+            _pad_connections!(eng_obj, "terminals", all_conductors)
         end
     end
 
     if haskey(data_eng, "line")
-        for (_, eng_obj) in data_eng["line"]
+        for (_,eng_obj) in data_eng["line"]
             _apply_linecode!(eng_obj, data_eng)
 
             _pad_properties!(eng_obj, ["rs", "xs", "g_fr", "g_to", "b_fr", "b_to"], eng_obj["f_connections"], all_conductors)
@@ -218,32 +220,34 @@ function pad_mc_properties!(data_eng::Dict{String,<:Any})
                 end
             end
 
-            eng_obj["f_connections"] = eng_obj["t_connections"] = all_conductors
+            _pad_connections!(eng_obj, "f_connections", all_conductors)
+            _pad_connections!(eng_obj, "t_connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "transformer")
-        for (id, eng_obj) in data_eng["transformer"]
+        for (_,eng_obj) in data_eng["transformer"]
             _apply_xfmrcode!(eng_obj, data_eng)
 
             if haskey(eng_obj, "f_connections")
                 _pad_properties!(eng_obj, ["tm_lb", "tm_ub", "tm_set"], eng_obj["f_connections"], all_conductors; pad_value=1.0)
                 _pad_properties!(eng_obj, ["tm_fix"], eng_obj["f_connections"], all_conductors; pad_value=false)
 
-                eng_obj["f_connections"] = eng_obj["t_connections"] = all_conductors
+                _pad_connections!(eng_obj, "f_connections", all_conductors)
+                _pad_connections!(eng_obj, "t_connections", all_conductors)
             else
                 for (w, connections) in enumerate(eng_obj["connections"])
                     _pad_properties!(eng_obj, ["tm_lb", "tm_ub", "tm_set"], w, connections, all_conductors; pad_value=1.0)
                     _pad_properties!(eng_obj, ["tm_fix"], w, connections, all_conductors; pad_value=false)
 
-                    eng_obj["connections"][w] = all_conductors
+                    _pad_connections!(eng_obj, "connections", w, all_conductors)
                 end
             end
         end
     end
 
     if haskey(data_eng, "switch")
-        for (_, eng_obj) in data_eng["switch"]
+        for (_,eng_obj) in data_eng["switch"]
             _apply_linecode!(eng_obj, data_eng)
 
             _pad_properties!(eng_obj, ["rs", "xs"], eng_obj["f_connections"], all_conductors)
@@ -255,66 +259,70 @@ function pad_mc_properties!(data_eng::Dict{String,<:Any})
                 end
             end
 
-            eng_obj["f_connections"] = all_conductors
-            eng_obj["t_connections"] = all_conductors
+            _pad_connections!(eng_obj, "f_connections", all_conductors)
+            _pad_connections!(eng_obj, "t_connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "shunt")
-        for (_, eng_obj) in data_eng["shunt"]
+        for (_,eng_obj) in data_eng["shunt"]
             _pad_properties!(eng_obj, ["gs", "bs"], eng_obj["connections"], all_conductors)
 
-            eng_obj["connections"] = all_conductors
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "load")
-        for (_, eng_obj) in data_eng["load"]
+        for (_,eng_obj) in data_eng["load"]
             if eng_obj["configuration"] == WYE
                 _pad_properties!(eng_obj, ["pd_nom", "qd_nom"], eng_obj["connections"], all_conductors)
             else
                 _pad_properties_delta!(eng_obj, ["pd_nom", "qd_nom"], eng_obj["connections"], all_conductors)
             end
 
-            eng_obj["connections"] = all_conductors
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "generator")
-        for (_, eng_obj) in data_eng["generator"]
+        for (_,eng_obj) in data_eng["generator"]
             if eng_obj["configuration"]==WYE
                 _pad_properties!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
             else
                 _pad_properties_delta!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
             end
+
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "solar")
-        for (_, eng_obj) in data_eng["solar"]
+        for (_,eng_obj) in data_eng["solar"]
             if eng_obj["configuration"]==WYE
                 _pad_properties!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
             else
                 _pad_properties_delta!(eng_obj, ["pg", "qg", "vg", "pg_lb", "pg_ub", "qg_lb", "qg_ub"], eng_obj["connections"], all_conductors)
             end
 
-            eng_obj["connections"] = all_conductors
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "storage")
-        for (_, eng_obj) in data_eng["storage"]
+        for (_,eng_obj) in data_eng["storage"]
             _pad_properties!(eng_obj, ["cm_ub", "qs_lb", "qs_ub", "rs", "xs", "ps", "qs"], eng_obj["connections"], all_conductors)
 
-            eng_obj["connections"] = all_conductors
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
 
     if haskey(data_eng, "voltage_source")
-        for (_, eng_obj) in data_eng["voltage_source"]
+        for (_,eng_obj) in data_eng["voltage_source"]
             _pad_properties!(eng_obj, ["pg", "qg", "pg_lb", "pg_ub", "qg_lb", "qg_ub", "vm", "va"], eng_obj["connections"], all_conductors)
 
-            eng_obj["connections"] = all_conductors
+            _pad_connections!(eng_obj, "connections", all_conductors)
         end
     end
+
+    data_eng["is_padded"] = true
 end

--- a/src/data_model/utils.jl
+++ b/src/data_model/utils.jl
@@ -144,7 +144,7 @@ end
 
 
 "loss model builder for transformer decomposition"
-function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::Any, to_map::Vector{String}, r_s::Vector{Float64}, zsc::Dict{Tuple{Int,Int},Complex{Float64}}, ysh::Complex{Float64}; nphases::Int=3, kron_reduced=false)::Vector{Int}
+function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::Any, to_map::Vector{String}, r_s::Vector{Float64}, zsc::Dict{Tuple{Int,Int},Complex{Float64}}, ysh::Complex{Float64}; nphases::Int=3)::Vector{Int}
     # precompute the minimal set of buses and lines
     N = length(r_s)
     tr_t_bus = collect(1:N)
@@ -227,7 +227,7 @@ function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::Any
             "index" => length(data_math["bus"])+1,
         )
 
-        if !kron_reduced
+        if !get(data_math, "is_kron_reduced", false)
             if bus in tr_t_bus
                 bus_obj["terminals"] = collect(1:nphases+1)
                 bus_obj["vmin"] = fill(0.0, nphases+1)
@@ -743,4 +743,24 @@ function _check_equal(data1::Dict{String,<:Any}, data2::Dict{String,<:Any}; cont
     end
 
     return lines
+end
+
+
+"adds conductors to connections during padding process"
+function _pad_connections!(eng_obj::Dict{String,<:Any}, connection_key::String, conductors::Union{Vector{Int},Vector{String}})
+    for cond in conductors
+        if !(cond in eng_obj[connection_key])
+            push!(eng_obj[connection_key], cond)
+        end
+    end
+end
+
+
+"adds conductors to connections during padding process, transformer winding variant"
+function _pad_connections!(eng_obj::Dict{String,<:Any}, connection_key::String, wdg::Int, conductors::Union{Vector{Int},Vector{String}})
+    for cond in conductors
+        if !(cond in eng_obj[connection_key][wdg])
+            push!(eng_obj[connection_key][wdg], cond)
+        end
+    end
 end

--- a/src/data_model/utils.jl
+++ b/src/data_model/utils.jl
@@ -144,7 +144,7 @@ end
 
 
 "loss model builder for transformer decomposition"
-function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::String, to_map::Vector{String}, r_s::Vector{Float64}, zsc::Dict{Tuple{Int,Int},Complex{Float64}}, ysh::Complex{Float64}; nphases::Int=3, kron_reduced=false)::Vector{Int}
+function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::Any, to_map::Vector{String}, r_s::Vector{Float64}, zsc::Dict{Tuple{Int,Int},Complex{Float64}}, ysh::Complex{Float64}; nphases::Int=3, kron_reduced=false)::Vector{Int}
     # precompute the minimal set of buses and lines
     N = length(r_s)
     tr_t_bus = collect(1:N)
@@ -364,6 +364,27 @@ function _pad_properties!(object::Dict{<:Any,<:Any}, properties::Vector{String},
 end
 
 
+"pads properties to have the total number of conductors for the whole system (transformer winding variant)"
+function _pad_properties!(object::Dict{<:Any,<:Any}, properties::Vector{String}, wdg::Int, connections::Vector{Int}, phases::Vector{Int}; pad_value::Real=0.0)
+    @assert(all(c in phases for c in connections))
+    inds = _get_idxs(phases, connections)
+
+    for property in properties
+        if haskey(object, property)
+            if isa(object[property][wdg], Vector)
+                tmp = fill(pad_value, length(phases))
+                tmp[inds] = object[property][wdg]
+                object[property][wdg] = tmp
+            elseif isa(object[property][wdg], Matrix)
+                tmp = fill(pad_value, length(phases), length(phases))
+                tmp[inds, inds] = object[property][wdg]
+                object[property][wdg] = tmp
+            end
+        end
+    end
+end
+
+
 "pads properties to have the total number of conductors for the whole system - delta connection variant"
 function _pad_properties_delta!(object::Dict{<:Any,<:Any}, properties::Vector{String}, connections::Vector{Int}, phases::Vector{Int}; invert::Bool=false)
     @assert(all(c in phases for c in connections))
@@ -404,6 +425,22 @@ function _apply_filter!(obj::Dict{String,<:Any}, properties::Vector{String}, fil
                 obj[property] = obj[property][filter]
             elseif isa(obj[property], Matrix)
                 obj[property] = obj[property][filter, filter]
+            else
+                Memento.error(_LOGGER, "The property $property is not a Vector or a Matrix!")
+            end
+        end
+    end
+end
+
+
+"Filters out values of a vector or matrix for certain properties (transformer winding variant)"
+function _apply_filter!(obj::Dict{String,<:Any}, properties::Vector{String}, wdg::Int, filter::Union{Array,BitArray})
+    for property in properties
+        if haskey(obj, property)
+            if isa(obj[property], Vector)
+                obj[property][wdg] = obj[property][wdg][filter]
+            elseif isa(obj[property], Matrix)
+                obj[property][wdg] = obj[property][wdg][filter, filter]
             else
                 Memento.error(_LOGGER, "The property $property is not a Vector or a Matrix!")
             end
@@ -480,11 +517,11 @@ function _apply_xfmrcode!(eng_obj::Dict{String,<:Any}, data_eng::Dict{String,<:A
 
         for (k, v) in xfmrcode
             if !haskey(eng_obj, k)
-                eng_obj[k] = v
+                eng_obj[k] = deepcopy(v)
             elseif haskey(eng_obj, k) && k in ["vm_nom", "sm_nom", "tm_set", "rw"]
                 for (w, vw) in enumerate(eng_obj[k])
                     if ismissing(vw)
-                        eng_obj[k][w] = v[w]
+                        eng_obj[k][w] = deepcopy(v[w])
                     end
                 end
             end
@@ -500,7 +537,7 @@ function _apply_linecode!(eng_obj::Dict{String,<:Any}, data_eng::Dict{String,<:A
 
         for property in ["rs", "xs", "g_fr", "g_to", "b_fr", "b_to"]
             if !haskey(eng_obj, property) && haskey(linecode, property)
-                eng_obj[property] = linecode[property]
+                eng_obj[property] = deepcopy(linecode[property])
             end
         end
     end
@@ -672,3 +709,38 @@ function _build_eng_multinetwork(data_eng::Dict{String,<:Any})::Dict{String,Any}
     end
 end
 
+
+"finds maximal set of ungrounded phases"
+function _get_complete_conductor_set(data::Dict{String,<:Any})
+    conductors = Set([])
+    for (_, obj) in data["bus"]
+        for t in obj["terminals"]
+            push!(conductors, t)
+        end
+    end
+
+    return sort([c for c in conductors])
+end
+
+
+"checks if data structures are equivalent, and if not, will enumerate the differences"
+function _check_equal(data1::Dict{String,<:Any}, data2::Dict{String,<:Any}; context::String="", ignore::Vector{String}=Vector{String}(["connections", "f_connections", "t_connections", "terminals"]))
+    lines = []
+    for (i, obj) in data1
+        if !haskey(data2, i)
+            push!(lines, "  $i missing in $data2")
+        else
+            if obj != data2[i]
+                if isa(obj, Dict)
+                    push!(lines, _check_equal(obj, data2[i]; context="  $context $i"))
+                else
+                    if !(i in ignore)
+                        push!(lines, "  $context $i: $obj != $(data2[i])")
+                    end
+                end
+            end
+        end
+    end
+
+    return lines
+end

--- a/src/data_model/utils.jl
+++ b/src/data_model/utils.jl
@@ -220,6 +220,7 @@ function _build_loss_model!(data_math::Dict{String,<:Any}, transformer_name::Any
             "bus_i" => length(data_math["bus"])+1,
             "vmin" => fill(0.0, nphases),
             "vmax" => fill(Inf, nphases),
+            "terminals" => collect(1:nphases),
             "grounded" => fill(false, nphases),
             "base_kv" => 1.0,
             "bus_type" => 1,

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -11,6 +11,7 @@ function parse_file(
     transformations::Vector{<:Any}=[],
     build_multinetwork::Bool=false,
     kron_reduced::Bool=true,
+    project_phases::Bool=true,
     time_series::String="daily"
         )::Dict{String,Any}
 
@@ -35,6 +36,7 @@ function parse_file(
             return transform_data_model(data_eng;
                 make_pu=true,
                 kron_reduced=kron_reduced,
+                project_phases=project_phases,
                 build_multinetwork=build_multinetwork
             )
         else
@@ -46,6 +48,7 @@ function parse_file(
         if pmd_data["data_model"] != data_model && data_model == ENGINEERING
             return transform_data_model(pmd_data;
                 kron_reduced=kron_reduced,
+                project_phases=project_phases,
                 build_multinetwork=build_multinetwork
             )
         else
@@ -70,6 +73,7 @@ end
 "transforms model between engineering (high-level) and mathematical (low-level) models"
 function transform_data_model(data::Dict{String,<:Any};
         kron_reduced::Bool=true,
+        project_phases::Bool=true,
         make_pu::Bool=true,
         build_multinetwork::Bool=false
             )::Dict{String,Any}
@@ -80,12 +84,12 @@ function transform_data_model(data::Dict{String,<:Any};
         if build_multinetwork && haskey(data, "time_series")
             mn_data = _build_eng_multinetwork(data)
             if ismultinetwork(mn_data)
-                data_math = _map_eng2math_multinetwork(mn_data; kron_reduced=kron_reduced)
+                data_math = _map_eng2math_multinetwork(mn_data; kron_reduced=kron_reduced, project_phases=project_phases)
             else
-                data_math = _map_eng2math(mn_data; kron_reduced=kron_reduced)
+                data_math = _map_eng2math(mn_data; kron_reduced=kron_reduced, project_phases=project_phases)
             end
         else
-            data_math = _map_eng2math(data; kron_reduced=kron_reduced)
+            data_math = _map_eng2math(data; kron_reduced=kron_reduced, project_phases=project_phases)
         end
 
         correct_network_data!(data_math; make_pu=make_pu)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -8,7 +8,7 @@ function parse_file(
     data_model::DataModel=ENGINEERING,
     import_all::Bool=false,
     bank_transformers::Bool=true,
-    transformations::Vector{<:Any}=[apply_kron_reduction!, pad_mc_properties!],
+    transformations::Vector{<:Any}=[],
     build_multinetwork::Bool=false,
     kron_reduced::Bool=true,
     time_series::String="daily"
@@ -21,6 +21,7 @@ function parse_file(
             time_series=time_series
         )
 
+        transformations = [transformations..., apply_kron_reduction!, pad_mc_properties!]  # TODO Remove in v0.10 (breaking)
         for transform in transformations
             @assert isa(transform, Function) || isa(transform, Tuple{<:Function,Vararg{Pair{String,<:Any}}})
 

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -16,7 +16,7 @@ function parse_file(
         )::Dict{String,Any}
 
     if filetype == "dss"
-        data_eng = PowerModelsDistribution.parse_opendss(io;
+        data_eng = parse_opendss(io;
             import_all=import_all,
             bank_transformers=bank_transformers,
             time_series=time_series

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -21,7 +21,6 @@ function parse_file(
             time_series=time_series
         )
 
-        transformations = [transformations..., apply_kron_reduction!, pad_mc_properties!]  # TODO Remove in v0.10 (breaking)
         for transform in transformations
             @assert isa(transform, Function) || isa(transform, Tuple{<:Function,Vararg{Pair{String,<:Any}}})
 
@@ -116,7 +115,7 @@ function correct_network_data!(data::Dict{String,Any}; make_pu::Bool=true)
                     nw["basekv"]  = maximum(maximum(bus["vbase"] for (_, bus) in nw["bus"]) for nw in values(data["nw"]))
                     nw["baseMVA"] = data["settings"]["sbase"]*data["settings"]["power_scale_factor"]/1E6
                 end
-            else ismultinetwork(data)
+            else
                 data["baseMVA"] = data["settings"]["sbase"]*data["settings"]["power_scale_factor"]/1E6
                 data["basekv"]  = maximum(bus["vbase"] for (_, bus) in data["bus"])
                 _PM.check_connectivity(data)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -8,7 +8,7 @@ function parse_file(
     data_model::DataModel=ENGINEERING,
     import_all::Bool=false,
     bank_transformers::Bool=true,
-    transformations::Vector{<:Any}=[],
+    transformations::Vector{<:Any}=[apply_kron_reduction!, pad_mc_properties!],
     build_multinetwork::Bool=false,
     kron_reduced::Bool=true,
     time_series::String="daily"

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -580,8 +580,10 @@ OpenDSS documentation for valid fields and ways to specify the different
 properties.
 """
 function _create_vsource(name::String=""; kwargs...)::Dict{String,Any}
-    bus1 = get(kwargs, :bus1, "sourcebus")
-    bus2 = get(kwargs, :bus2, "")
+    phases = get(kwargs, :phases, 3)
+
+    bus1 = get(kwargs, :bus1, "sourcebus.$(join(1:phases, "."))")
+    bus2 = get(kwargs, :bus2, replace(bus1, r"\.\d" => ".0"))
 
     x1r1 = get(kwargs, :x1r1, 4.0)
     x0r0 = get(kwargs, :x0r0, 3.0)
@@ -593,7 +595,6 @@ function _create_vsource(name::String=""; kwargs...)::Dict{String,Any}
     xs = 0.1
     xm = 0.0
 
-    phases = get(kwargs, :phases, 3)
     factor = phases == 1 ? 1.0 : sqrt(3.0)
 
     mvasc3 = get(kwargs, :mvasc3, 2000.0)

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -716,10 +716,6 @@ function _dss2eng_transformer!(data_eng::Dict{String,<:Any}, data_dss::Dict{Stri
             end
         end
 
-        if !haskey(data_eng, "transformer")
-            data_eng["transformer"] = Dict{String,Any}()
-        end
-
         if import_all
             _import_all!(eng_obj, dss_obj)
         end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -322,7 +322,7 @@ function _dss2eng_generator!(data_eng::Dict{String,<:Any}, data_dss::Dict{String
 
         eng_obj = Dict{String,Any}(
             "phases" => nphases,
-            "connections" => _get_conductors_ordered(defaults["bus1"], pad_ground=true, default=collect(1:defaults["phases"]+1)),
+            "connections" => _get_conductors_ordered(defaults["bus1"], pad_ground=true, default=[collect(1:defaults["phases"])..., 0]),
             "bus" => _parse_bus_id(defaults["bus1"])[1],
             "pg" => fill(defaults["kw"] / nphases, nphases),
             "qg" => fill(defaults["kvar"] / nphases, nphases),
@@ -359,7 +359,6 @@ function _dss2eng_vsource!(data_eng::Dict{String,<:Any}, data_dss::Dict{String,<
         _apply_like!(dss_obj, data_dss, "vsource")
         defaults = _create_vsource(id; _to_kwargs(dss_obj)...)
 
-
         ph1_ang = defaults["angle"]
         vm_pu = defaults["pu"]
 
@@ -371,7 +370,7 @@ function _dss2eng_vsource!(data_eng::Dict{String,<:Any}, data_dss::Dict{String,<
 
         eng_obj = Dict{String,Any}(
             "bus" => _parse_bus_id(defaults["bus1"])[1],
-            "connections" => collect(1:phases),
+            "connections" => _get_conductors_ordered(defaults["bus1"]; default=[collect(1:phases)..., 0], pad_ground=true),
             "vm" => vm,
             "va" => va,
             "rs" => defaults["rmatrix"],

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -371,13 +371,23 @@ function _dss2eng_vsource!(data_eng::Dict{String,<:Any}, data_dss::Dict{String,<
         eng_obj = Dict{String,Any}(
             "bus" => _parse_bus_id(defaults["bus1"])[1],
             "connections" => _get_conductors_ordered(defaults["bus1"]; default=[collect(1:phases)..., 0], pad_ground=true),
-            "vm" => vm,
-            "va" => va,
-            "rs" => defaults["rmatrix"],
-            "xs" => defaults["xmatrix"],
             "source_id" => "vsource.$id",
             "status" => defaults["enabled"] ? ENABLED : DISABLED
         )
+
+        # some values require addition of neutral by default
+        n_conductors = length(eng_obj["connections"])
+        eng_obj["rs"] = zeros(n_conductors, n_conductors)
+        eng_obj["rs"][1:phases, 1:phases] = defaults["rmatrix"]
+
+        eng_obj["xs"] = zeros(n_conductors, n_conductors)
+        eng_obj["xs"][1:phases, 1:phases] = defaults["xmatrix"]
+
+        eng_obj["vm"] = zeros(n_conductors)
+        eng_obj["vm"][1:phases] = vm
+
+        eng_obj["va"] = zeros(n_conductors)
+        eng_obj["va"][1:phases] = va
 
         # if the ground is used directly, register load
         if 0 in eng_obj["connections"]

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -399,7 +399,7 @@ function _discover_terminals!(data_eng::Dict{String,<:Any})
         end
     end
 
-    for comp_type in [x for x in ["voltage_source", "load", "gen"] if haskey(data_eng, x)]
+    for comp_type in [x for x in ["voltage_source", "load", "generator", "solar"] if haskey(data_eng, x)]
         for comp in values(data_eng[comp_type])
             push!(terminals[comp["bus"]], setdiff(comp["connections"], [0])...)
         end

--- a/test/data_model.jl
+++ b/test/data_model.jl
@@ -8,7 +8,7 @@
         add_bus!(eng, "primary"; terminals=[1,2,3])
         add_bus!(eng, "loadbus"; terminals=[1,2,3,4], grounded=[4])
 
-        add_voltage_source!(eng, "source", "sourcebus", [1,2,3,4]; vm=[1, 1, 1])
+        add_voltage_source!(eng, "source", "sourcebus", [1,2,3,4]; vm=[1, 1, 1, 0])
 
         add_linecode!(eng, "default", diagm(0=>fill(0.01, 3)), diagm(0=>fill(0.2, 3)))
 

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -2,7 +2,7 @@
 
 @testset "test opendss parser" begin
     @testset "bus discovery parsing" begin
-        eng = parse_file("../test/data/opendss/test_bus_discovery.dss")
+        eng = parse_file("../test/data/opendss/test_bus_discovery.dss"; transformations=[])
 
         @test length(eng["bus"]) == 24
         @test all(k in keys(eng["bus"]) for k in [["$i" for i in 1:23]..., "sourcebus"])
@@ -227,7 +227,7 @@
 end
 
 @testset "test json parser" begin
-    eng = parse_file("../test/data/opendss/case3_balanced.dss")
+    eng = parse_file("../test/data/opendss/case3_balanced.dss"; transformations=[])
 
     io = PipeBuffer()
     print_file(io, eng)

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -108,7 +108,7 @@
 
         @test math["name"] == "test2"
 
-        @test length(math) == 18
+        @test length(math) == 20
         @test length(dss) == 16
 
         for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer"], [33, 4, 5, 27, 4, 0, 10])
@@ -227,7 +227,7 @@
 end
 
 @testset "test json parser" begin
-    eng = parse_file("../test/data/opendss/case3_balanced.dss"; transformations=[])
+    eng = parse_file("../test/data/opendss/case3_balanced.dss")
 
     io = PipeBuffer()
     print_file(io, eng)

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -2,7 +2,7 @@
 
 @testset "test opendss parser" begin
     @testset "bus discovery parsing" begin
-        eng = parse_file("../test/data/opendss/test_bus_discovery.dss"; transformations=[])
+        eng = parse_file("../test/data/opendss/test_bus_discovery.dss")
 
         @test length(eng["bus"]) == 24
         @test all(k in keys(eng["bus"]) for k in [["$i" for i in 1:23]..., "sourcebus"])

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -17,7 +17,6 @@
         end
 
         @testset "2w transformer acp pf dy_lag" begin
-            file =
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lag.dss")
             sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.92092, 0.91012, 0.90059], Inf) <= 1.5E-5


### PR DESCRIPTION
This PR refactors the kron reduction and padding transformations from within the individual eng2math conversion functions into their own functions inside of `src/data_models/transformations.jl` so that they can be applied to the engineering data model separately. This is in preparation for the addition of explicit 4-wire support to be added in v0.10.0.

In order to maintain backwards compatibility for the remainder of v0.9, the kron reduction and padding transformations are automatically applied during the call of the `eng2math` functions, and therefore during `transform_data_model`. This automatic transformation is expected to be removed at a future date. Furthermore, the user will not see the engineering data model after these transformations have been applied (unless they are invoked separately by the user) in all of the normal workflows. As can be seen in the file changes, unit test updates were very minor.

This PR adds two functions, `apply_kron_reduction!` and `apply_phase_projection!`, the calling of which will add `"is_kron_reduced"=>true` and `"is_projected"=>true`, respectively, to the top-level of the engineering data structure (and will propagate down to the mathematical data structure). `apply_kron_reduction!` performs two actions, (1) removes the neutral conductors of lines and compensates them through a kron reduction of the impedance, (2) removes all neutral terminals from the problem. `is_kron_reduced` will therefore indicate a departure from the engineering data model specification, where grounded neutrals are expected for certain objects, because 

`apply_phase_projection!` projects all components less than the total number of conductors over the whole network to that number of phases, _e.g._ if the network is overall three-phases, but there are some one and two phase components, the phases that are not connected on those components will be padded so that every component is three phases.

No documentation changes were required at this stage.