### PR TITLE
FIX: some properties missing on dss lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fix missing / incorrect type of some properties on lines in opendss parser (#290)
 - Refactors Kron reduction and padding transformations out of eng2math into their own transformation functions (#287)
 - Add functionality of run_mc_mld_bf to run_mc_mld via multiple dispatch
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -104,9 +104,10 @@ const _capacitor_properties = Vector{String}([
 
 const _line_properties = Vector{String}([
     "bus1", "bus2", "linecode", "length", "phases", "r1", "x1", "r0", "x0",
-    "c1", "c0", "b1", "b0", "normamps", "emergamps", "faultrate", "pctperm",
+    "c1", "c0", "normamps", "emergamps", "faultrate", "pctperm",
     "repair", "basefreq", "rmatrix", "xmatrix", "cmatrix", "switch", "rg",
-    "xg", "rho", "geometry", "earthmodel", "units", "enabled", "like"
+    "xg", "rho", "geometry", "units", "spacing", "wires", "earthmodel",
+    "cncables", "tscables", "b1", "b0", "seasons", "ratings", "enabled", "like"
 ])
 
 const _reactor_properties = Vector{String}([

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -217,10 +217,10 @@ function _create_line(name::String=""; kwargs...)::Dict{String,Any}
         "geometry" => get(kwargs, :geometry, ""),
         "units" => "m",
         "spacing" => get(kwargs, :spacing, ""),
-        "wires" => get(kwargs, :wires, ""),
+        "wires" => get(kwargs, :wires, Vector{String}([])),
         "earthmodel" => get(kwargs, :earthmodel, ""),
-        "cncables" => get(kwargs, :cncables, ""),
-        "tscables" => get(kwargs, :tscables, ""),
+        "cncables" => get(kwargs, :cncables, Vector{String}([])),
+        "tscables" => get(kwargs, :tscables, Vector{String}([])),
         "b1" => b1 / _convert_to_meters[units],
         "b0" => b0 / _convert_to_meters[units],
         # Inherited Properties

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -80,3 +80,10 @@ new xfmrcode.t1 phases=1 windings=2 conns=[wye,wye] kvs=[15, 15] kvas=[50000 500
 
 new loadshape.ld3_yearly pmult=(sngfile=load_profile.sng)
 new loadshape.ld2_daily pmult=(file=load_profile.csv)
+
+new linespacing.test_spacing
+
+new wiredata.wire1
+new wiredata.wire2
+
+new line.l9 bus1=b10 bus2=b11 spacing=test_spacing wires=['wire1', 'wire2'] length=10

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -109,9 +109,9 @@
         @test math["name"] == "test2"
 
         @test length(math) == 20
-        @test length(dss) == 16
+        @test length(dss) == 18
 
-        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer"], [33, 4, 5, 27, 4, 0, 10])
+        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer"], [33, 4, 5, 28, 4, 0, 10])
             @test haskey(math, key)
             @test length(math[key]) == len
         end
@@ -160,6 +160,15 @@
 
         eng_data = parse_file("../test/data/opendss/test_transformer_formatting.dss")
         @test all(all(eng_data["transformer"]["$n"]["tm_set"] .==  tm) for (n, tm) in zip(["transformer_test", "reg4"], [[fill(1.075, 3), fill(1.5, 3), fill(0.9, 3)], [ones(3), ones(3)]]))
+    end
+
+    @testset "opendss parse line parsing wires - spacing properties" begin
+        dss_data = parse_dss("../test/data/opendss/test2_master.dss")
+
+        @test isa(dss_data["line"]["l9"]["wires"], Vector{String}) && all(dss_data["line"]["l9"]["wires"] .== ["wire1", "wire2"])
+        @test dss_data["line"]["l9"]["spacing"] == "test_spacing"
+        @test haskey(dss_data, "wiredata") && (haskey(dss_data["wiredata"], "wire1") && haskey(dss_data["wiredata"], "wire2"))
+        @test haskey(dss_data, "linespacing") && haskey(dss_data["linespacing"], "test_spacing")
     end
 
     @testset "opendss parse storage" begin


### PR DESCRIPTION
Several undocumented properties on dss lines were missing from the
ordered property lists within the opendss parser, including

- `spacing`,
- `wires`,
- `cncables`,
- `tscables`,
- `seasons`, and
- `ratings`.

In addition, while these properties were include in the line struct
definition, several of the default property types were incorrect. In
particular, `wires`, `cncables`, and `tscables` should be vectors
of type string.