### PR TITLE
FIX: connections on generation type components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fix connections-determining-code on solar and storage objects to generator object syntax (#291)
 - Refactors Kron reduction and padding transformations out of eng2math into their own transformation functions (#287)
 - Add functionality of run_mc_mld_bf to run_mc_mld via multiple dispatch
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -747,7 +747,7 @@ function _dss2eng_pvsystem!(data_eng::Dict{String,<:Any}, data_dss::Dict{String,
         eng_obj = Dict{String,Any}(
             "bus" => _parse_bus_id(defaults["bus1"])[1],
             "configuration" => defaults["conn"],
-            "connections" => _get_conductors_ordered(defaults["bus1"], pad_ground=true, default=collect(1:defaults["phases"]+1)),
+            "connections" => _get_conductors_ordered(defaults["bus1"], pad_ground=true, default=[collect(1:defaults["phases"])..., 0]),
             "pg" => fill(defaults["kva"] / nphases, nphases),
             "qg" => fill(defaults["kvar"] / nphases, nphases),
             "vg" => fill(defaults["kv"] / nphases, nphases),
@@ -792,7 +792,7 @@ function _dss2eng_storage!(data_eng::Dict{String,<:Any}, data_dss::Dict{String,<
 
         eng_obj = Dict{String,Any}(
             "bus" => _parse_bus_id(defaults["bus1"])[1],
-            "connections" => _get_conductors_ordered(defaults["bus1"], check_length=false),
+            "connections" => _get_conductors_ordered(defaults["bus1"], pad_ground=true, default=[collect(1:defaults["phases"])..., 0]),
             "configuration" => WYE,
             "energy" => defaults["kwhstored"],
             "energy_ub" => defaults["kwrated"],

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -80,3 +80,6 @@ new xfmrcode.t1 phases=1 windings=2 conns=[wye,wye] kvs=[15, 15] kvas=[50000 500
 
 new loadshape.ld3_yearly pmult=(sngfile=load_profile.sng)
 new loadshape.ld2_daily pmult=(file=load_profile.csv)
+
+new storage.s1 bus1=b1
+new pvsystem.solar1 bus1=b1

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -92,6 +92,13 @@
     eng = parse_file("../test/data/opendss/test2_master.dss", import_all=true)
     math = parse_file("../test/data/opendss/test2_master.dss"; data_model=MATHEMATICAL, import_all=true)
 
+    @testset "multiple generation objects on same bus" begin
+        @test all(eng["storage"]["s1"]["connections"] .== collect(1:4))
+        @test all(eng["solar"]["solar1"]["connections"] .== collect(1:4))
+        @test all(eng["bus"]["b1"]["terminals"] .== collect(1:4))
+        @test eng["bus"]["b1"]["grounded"] == [4]
+    end
+
     @testset "buscoords automatic parsing" begin
         @test all(haskey(bus, "lon") && haskey(bus, "lat") for bus in values(math["bus"]) if "bus_i" in 1:10)
     end
@@ -109,9 +116,9 @@
         @test math["name"] == "test2"
 
         @test length(math) == 20
-        @test length(dss) == 16
+        @test length(dss) == 18
 
-        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer"], [33, 4, 5, 27, 4, 0, 10])
+        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline", "transformer", "storage"], [33, 4, 5, 27, 5, 0, 10, 1])
             @test haskey(math, key)
             @test length(math[key]) == len
         end


### PR DESCRIPTION
The syntax for adding a ground by default to generation type dss
objects was incorrect, and have been changed to match the syntax
on `generator` objects such that objects have awaiting ground
added automatically by default in such a way that multiple grounds
don't get added to the bus which causes problems with kron reduction.