### PR TITLE
FIX: typo on line 548 of form/ivr.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Refactors Kron reduction and padding transformations out of eng2math into their own transformation functions (#287)
 - Add functionality of run_mc_mld_bf to run_mc_mld via multiple dispatch
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)
-- Add a transformation remove_all_bounds! that removes all fields ending in _ub acd _lb (#278)
+- Add a transformation remove_all_bounds! that removes all fields ending in _ub and _lb (#278)
 - Add missing connections for virtual generator at voltage source
 - Fix pu conversion bus voltage bounds and add parsing for vm_pair_lb and vm_pair_ub
 - Add CONTRIBUTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## staged
 
+- Fix typo in ivr formulation line 548, was var(pm, nw, :crg_bus, id) now is var(pm, nw, :cig_bus, id)
 - Fix missing / incorrect type of some properties on lines in opendss parser (#290)
 - Fix connections-determining-code on solar and storage objects to generator object syntax (#291)
 - Refactors Kron reduction and padding transformations out of eng2math into their own transformation functions (#287)
 - Add functionality of run_mc_mld_bf to run_mc_mld via multiple dispatch
 - Fixes inconsistency of connections on MATHEMATICAL components, in particular, virtual objects (#280)
-- Add a transformation remove_all_bounds! that removes all fields ending in _ub and _lb (#278)
+- Add a transformation remove_all_bounds! that removes all fields ending in _ub acd _lb (#278)
 - Add missing connections for virtual generator at voltage source
 - Fix pu conversion bus voltage bounds and add parsing for vm_pair_lb and vm_pair_ub
 - Add CONTRIBUTING.md

--- a/src/form/ivr.jl
+++ b/src/form/ivr.jl
@@ -545,7 +545,7 @@ function constraint_mc_gen_setpoint_wye(pm::_PM.IVRPowerModel, nw::Int, id::Int,
 
     if report
         sol(pm, nw, :gen, id)[:crg_bus] = var(pm, nw, :crg_bus, id)
-        sol(pm, nw, :gen, id)[:cig_bus] = var(pm, nw, :crg_bus, id)
+        sol(pm, nw, :gen, id)[:cig_bus] = var(pm, nw, :cig_bus, id)
 
         sol(pm, nw, :gen, id)[:pg] = pg
         sol(pm, nw, :gen, id)[:qg] = qg


### PR DESCRIPTION
`sol(pm, nw, :gen, id)[:cig_bus] = var(pm, nw, :crg_bus, id)` corrected to `sol(pm, nw, :gen, id)[:cig_bus] = var(pm, nw, :cig_bus, id)`

Should I make an entry in the changelog for this very small fix?