### PR TITLE
FIX: variables start value iteration per active connection (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # PowerModelsDistribution.jl Change Log
 
+- Fixes bug in assignment of variables' start values over active conductors/connections
+
 ## v0.10.0
 
 - Refactor variables, constraints, objectives to support iterating over arbitrary connections/terminals (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # PowerModelsDistribution.jl Change Log
 
+## Staged
+
 - Fixes bug in assignment of variables' start values over active conductors/connections
 
 ## v0.10.0

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,5 +1,5 @@
 
-function _get_conductor_indicator(comp::Dict{String,<:Any})
+function _get_conductor_indicator(comp::Dict{String,<:Any})::String
     if haskey(comp, "terminals")
         return "terminals"
     elseif haskey(comp, "connections")

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,7 +1,21 @@
 
+function _get_conductor_indicator(comp::Dict{String,<:Any})
+    if haskey(comp, "terminals")
+        return "terminals"
+    elseif haskey(comp, "connections")
+        return "connections"
+    elseif haskey(comp, "f_connections")
+        return "f_connections"
+    else
+        return ""
+    end
+end
+
+
 function comp_start_value(comp::Dict{String,<:Any}, key::String, conductor::Int, default)
-    if haskey(comp, key)
-        return comp[key][conductor]
+    cond_ind = _get_conductor_indicator(comp)
+    if haskey(comp, key) && !isempty(cond_ind)
+        return comp[key][findfirst(isequal(conductor), comp[cond_ind])]
     else
         return default
     end

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -274,5 +274,32 @@
             @test isapprox(sol_ivr["objective"], sol_ivr_with_start["objective"]; atol=1e-5)
             @test isapprox(sol_acr["objective"], sol_acr_with_start["objective"]; atol=1e-5)
         end
+
+        @testset "assign start value per connection iteration" begin
+            data = parse_file("../test/data/opendss/case3_unbalanced.dss"; data_model = MATHEMATICAL)
+            #add a single-phase generator and assign a single-phase start value to it
+            data["gen"]["2"] = Dict{String, Any}(
+                                "pg_start"      => [-0.012],
+                                "qg_start"      => [-0.006],
+                                "model"         => 2,
+                                "connections"   => [2],
+                                "shutdown"      => 0.0,
+                                "startup"       => 0.0,
+                                "configuration" => WYE,
+                                "name"          => "single_ph_generator",
+                                "gen_bus"       => 3,
+                                "pmax"          => [Inf],
+                                "vbase"         => 0.23094,
+                                "index"         => 2,
+                                "cost"          => [0.5, 0.0],
+                                "gen_status"    => 1,
+                                "qmax"          => [Inf],
+                                "qmin"          => [-Inf],
+                                "pmin"          => [-Inf],
+                                "ncost"         => 2
+                                )
+            sol = run_mc_opf(data, ACPPowerModel, ipopt_solver)
+            @test sol["termination_status"] == LOCALLY_SOLVED
+        end
     end
 end


### PR DESCRIPTION
- The purpose of this PR is to fix the bug in the assignment of variables' start values to active connections and closes #318 .
For this purpose, _get_conductor_indicator is added and called in  comp_start_value , both to be found in core/variable.jl.  It wasn't possible to reduce _get_conductor_indicator to a ternary operator, because there are more than two different active connections keys: "terminals" (for buses), "connections" (for loads and gens), and "f_connections" and "t_connections" for branches. In the case of branches, "f_connections" are chosen because, as far as I can see, assigning start values to branch variables corresponds to assigning start values to their "from" configuration.
- A test is added in test/opf.jl : it checks that the variable assignment doesn't interfere with the opf problem, which locally solves
