### PR TITLE
FIX: bug in parsing of dss edit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## staged
 
 - Fix bug in handling of dss edit command
+- Fix bug in correctly tracking current transformer winding
 
 ## v0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerModelsDistribution.jl Change Log
 
+## staged
+
+- Fix bug in handling of dss edit command
+
 ## v0.10.0
 
 - Refactor variables, constraints, objectives to support iterating over arbitrary connections/terminals (breaking)

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -578,6 +578,8 @@ function _add_component_edits!(data_dss::Dict{String,<:Any}, obj_type_name::SubS
         if !haskey(data_dss[obj_type], object["name"])
             data_dss[obj_type][object["name"]] = object
         else
+            filtered_prop_order = filter(x->x!="name", object["prop_order"])
+            object["prop_order"] = vcat(filter(x->!(x in filtered_prop_order), data_dss[obj_type][object["name"]]["prop_order"]), filtered_prop_order)
             merge!(data_dss[obj_type][object["name"]], object)
         end
     end

--- a/test/data/opendss/test2_edit.dss
+++ b/test/data/opendss/test2_edit.dss
@@ -1,0 +1,1 @@
+edit transformer.t5 wdg=2 %r=0.76 wdg=1 %r=0.74

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -92,4 +92,4 @@ new line.l9 bus1=b10 bus2=b11 spacing=test_spacing wires=['wire1', 'wire2'] leng
 new storage.s1 bus1=b1
 new pvsystem.solar1 bus1=b1
 
-edit transformer.t5 wdg=1 %r=0.76
+redirect test2_edit.dss

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -91,3 +91,5 @@ new line.l9 bus1=b10 bus2=b11 spacing=test_spacing wires=['wire1', 'wire2'] leng
 
 new storage.s1 bus1=b1
 new pvsystem.solar1 bus1=b1
+
+edit transformer.t5 wdg=1 %r=0.76

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -92,6 +92,11 @@
     eng = parse_file("../test/data/opendss/test2_master.dss", import_all=true)
     math = parse_file("../test/data/opendss/test2_master.dss"; data_model=MATHEMATICAL, import_all=true)
 
+    @testset "dss edit command" begin
+        @test all(eng["transformer"]["t5"][k] == v for (k,v) in eng["transformer"]["t4"] if !(k in ["bus", "source_id", "rw", "tm_set", "dss"]))
+        @test all(eng["transformer"]["t5"]["rw"] .== [0.0076, 0.0075])
+    end
+
     @testset "subdirectory parsing" begin
         @test haskey(eng["linecode"], "lc7")
     end

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -94,7 +94,7 @@
 
     @testset "dss edit command" begin
         @test all(eng["transformer"]["t5"][k] == v for (k,v) in eng["transformer"]["t4"] if !(k in ["bus", "source_id", "rw", "tm_set", "dss"]))
-        @test all(eng["transformer"]["t5"]["rw"] .== [0.0076, 0.0075])
+        @test all(eng["transformer"]["t5"]["rw"] .== [0.0074, 0.0076])
     end
 
     @testset "subdirectory parsing" begin


### PR DESCRIPTION
When parsing the dss edit commands, "prop_order" was getting overwritten
by the new object, instead of the "prop_order" getting appended to. This
fixes that problem, and now all previously parsed properties should
appear in the final parsed object.

Adds unit test and updates changelog.
