### PR TITLE
REF: depreciate `run_` functions for `solve_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## staged
 
+- depreciate run_ functions in favor of solve_
+- add support for `relax_integrality` (InfrastructureModels ~0.5.4)
+
 ## v0.10.1
 
 - Fix buspairs ref not getting built

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Cbc = ">= 0.4"
-InfrastructureModels = "~0.5"
+InfrastructureModels = "~0.5.4"
 Ipopt = ">= 0.4"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
 JuMP = "~0.21"

--- a/examples/engineering_model.ipynb
+++ b/examples/engineering_model.ipynb
@@ -625,14 +625,14 @@
     }
    ],
    "source": [
-    "result = run_mc_opf(eng, ACPPowerModel, ipopt_solver)"
+    "result = solve_mc_opf(eng, ACPPowerModel, ipopt_solver)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result of `run_mc_opf` will be very familiar to those who are already familiar with PowerModels and PowerModelsDistribution. The notable difference will be in the `\"solution\"` dictionary"
+    "The result of `solve_mc_opf` will be very familiar to those who are already familiar with PowerModels and PowerModelsDistribution. The notable difference will be in the `\"solution\"` dictionary"
    ]
   },
   {
@@ -723,7 +723,7 @@
     }
    ],
    "source": [
-    "result_pu = run_mc_opf(eng, ACPPowerModel, ipopt_solver; make_si=false)\n",
+    "result_pu = solve_mc_opf(eng, ACPPowerModel, ipopt_solver; make_si=false)\n",
     "\n",
     "result_pu[\"solution\"][\"bus\"][\"loadbus\"]"
    ]
@@ -769,7 +769,7 @@
     }
    ],
    "source": [
-    "result_bf = run_mc_opf(eng, SOCNLPUBFPowerModel, ipopt_solver)"
+    "result_bf = solve_mc_opf(eng, SOCNLPUBFPowerModel, ipopt_solver)"
    ]
   },
   {
@@ -808,7 +808,7 @@
     }
    ],
    "source": [
-    "result_mn = PowerModelsDistribution._run_mc_mn_opb(eng_ts, NFAPowerModel, ipopt_solver)"
+    "result_mn = PowerModelsDistribution._solve_mn_mc_opb(eng_ts, NFAPowerModel, ipopt_solver)"
    ]
   },
   {
@@ -1349,7 +1349,7 @@
     }
    ],
    "source": [
-    "result_math = run_mc_opf(math, ACPPowerModel, ipopt_solver)\n",
+    "result_math = solve_mc_opf(math, ACPPowerModel, ipopt_solver)\n",
     "\n",
     "result_math[\"solution\"]"
    ]
@@ -1416,7 +1416,7 @@
     }
    ],
    "source": [
-    "result_math_mn = PowerModelsDistribution._run_mc_mn_opb(math_mn, NFAPowerModel, ipopt_solver)\n",
+    "result_math_mn = PowerModelsDistribution._solve_mn_mc_opb(math_mn, NFAPowerModel, ipopt_solver)\n",
     "\n",
     "result_math_mn[\"solution\"][\"nw\"][\"1\"]"
    ]

--- a/examples/engineering_model_helper_functions.ipynb
+++ b/examples/engineering_model_helper_functions.ipynb
@@ -192,7 +192,7 @@
     }
    ],
    "source": [
-    "result = run_mc_opf(eng, ACPPowerModel, ipopt_solver)"
+    "result = solve_mc_opf(eng, ACPPowerModel, ipopt_solver)"
    ]
   },
   {
@@ -283,7 +283,7 @@
     }
    ],
    "source": [
-    "result2 = run_mc_opf(eng2, ACPPowerModel, ipopt_solver)"
+    "result2 = solve_mc_opf(eng2, ACPPowerModel, ipopt_solver)"
    ]
   }
  ],

--- a/src/prob/common.jl
+++ b/src/prob/common.jl
@@ -1,5 +1,5 @@
 "alias to run_model in PowerModels with multiconductor=true, and transformer ref extensions added by default"
-function run_mc_model(data::Dict{String,<:Any}, model_type::Type, solver, build_mc::Function; ref_extensions::Vector{<:Function}=Vector{Function}([]), make_si=!get(data, "per_unit", false), multinetwork::Bool=false, kwargs...)::Dict{String,Any}
+function solve_mc_model(data::Dict{String,<:Any}, model_type::Type, solver, build_mc::Function; ref_extensions::Vector{<:Function}=Vector{Function}([]), make_si=!get(data, "per_unit", false), multinetwork::Bool=false, kwargs...)::Dict{String,Any}
     if get(data, "data_model", MATHEMATICAL) == ENGINEERING
         data_math = transform_data_model(data; build_multinetwork=multinetwork)
 
@@ -15,6 +15,13 @@ end
 
 
 "alias to run_model in PowerModels with multiconductor=true, and transformer ref extensions added by default"
-function run_mc_model(file::String, model_type::Type, solver, build_mc::Function; ref_extensions::Vector{<:Function}=Vector{Function}([]), kwargs...)::Dict{String,Any}
-    return run_mc_model(parse_file(file), model_type, solver, build_mc; ref_extensions=ref_extensions, kwargs...)
+function solve_mc_model(file::String, model_type::Type, solver, build_mc::Function; ref_extensions::Vector{<:Function}=Vector{Function}([]), kwargs...)::Dict{String,Any}
+    return solve_mc_model(parse_file(file), model_type, solver, build_mc; ref_extensions=ref_extensions, kwargs...)
+end
+
+
+"depreciation message for run_mc_model"
+function run_mc_model(data::Union{String,Dict{String,<:Any}}, model_type::Type, solver, build_mc::Function; kwargs...)::Dict{String,Any}
+    @warn "run_mc_model is being depreciated in favor of solve_mc_model, please update your code accordingly"
+    return solve_mc_model(data, model_type, solver, build_mc; kwargs...)
 end

--- a/src/prob/debug.jl
+++ b/src/prob/debug.jl
@@ -1,14 +1,14 @@
 # These problem formulations are used to debug Distribution datasets
 # that do not converge using the standard formulations
-"OPF problem with slack power at every bus"
-function run_mc_opf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_opf_pbs; kwargs...)
+"Solve OPF problem with slack power at every bus"
+function solve_mc_opf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_opf_pbs; kwargs...)
 end
 
 
-"PF problem with slack power at every bus"
-function run_mc_pf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_pf_pbs; kwargs...)
+"Solve PF problem with slack power at every bus"
+function solve_mc_pf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_pf_pbs; kwargs...)
 end
 
 
@@ -90,4 +90,19 @@ function build_mc_pf_pbs(pm::_PM.AbstractPowerModel)
     end
 
     objective_mc_min_slack_bus_power(pm)
+end
+
+# Depreciated run_ functions (remove after ~4-6 months)
+
+"depreciation message for run_mc_opf_pbs"
+function run_mc_opf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_opf_pbs is being depreciated in favor of solve_mc_opf_pbs, please update your code accordingly"
+    return solve_mc_opf_pbs(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation message for run_mc_opf_pbs"
+function run_mc_pf_pbs(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_pf_pbs is being depreciated in favor of solve_mc_pf_pbs, please update your code accordingly"
+    return solve_mc_pf_pbs(data, model_type, solver; kwargs...)
 end

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -1,25 +1,18 @@
-"Run load shedding problem with storage"
-function run_mc_mld(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_mld; kwargs...)
+"Solve load shedding problem with storage"
+function solve_mc_mld(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_mld; kwargs...)
 end
 
 
-"Run multinetwork load shedding problem with storage"
-function run_mn_mc_mld_simple(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mn_mc_mld_simple; multinetwork=true, kwargs...)
+"Solve multinetwork load shedding problem with storage"
+function solve_mn_mc_mld_simple(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mn_mc_mld_simple; multinetwork=true, kwargs...)
 end
 
 
-"Run Branch Flow Model Load Shedding Problem"
-function run_mc_mld_bf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    Memento.info(_LOGGER, "We recommend using run_mc_mld, which will attempt to select appropriate variables and constraints based on the specified formulation, instead of run_mc_mld_bf")
-    return run_mc_model(data, model_type, solver, build_mc_mld_bf; kwargs...)
-end
-
-
-"Run unit commitment load shedding problem (!relaxed)"
-function run_mc_mld_uc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_mld_uc; kwargs...)
+"Solve unit commitment load shedding problem (!relaxed)"
+function solve_mc_mld_uc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_mld_uc; kwargs...)
 end
 
 
@@ -95,7 +88,7 @@ function build_mc_mld(pm::_PM.AbstractIVRModel)
 end
 
 
-"Multinetwork load shedding problem including storage (snap-shot)"
+"Multinetwork load shedding problem including storage"
 function build_mn_mc_mld_simple(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
         variable_mc_branch_power(pm; nw=n)
@@ -306,6 +299,8 @@ end
 
 "Load shedding problem for Branch Flow model"
 function build_mc_mld_bf(pm::_PM.AbstractPowerModel)
+    build_mc_mld(pm)
+
     variable_mc_bus_voltage_indicator(pm; relax=true)
     variable_mc_bus_voltage_on_off(pm)
 
@@ -421,4 +416,33 @@ function build_mc_mld_uc(pm::_PM.AbstractPowerModel)
     end
 
     objective_mc_min_load_setpoint_delta(pm)
+end
+
+# Depreciated run_ functions (remove after ~4-6 months)
+
+"depreciation warning for run_mc_mld"
+function run_mc_mld(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_mld is being depreciated in favor of solve_mc_mld, please update your code accordingly"
+    return solve_mc_mld(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mn_mc_mld_simple"
+function run_mn_mc_mld_simple(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mn_mc_mld_simple is being depreciated in favor of solve_mn_mc_mld_simple, please update your code accordingly"
+    return solve_mn_mc_mld_simple(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mc_mld_bf"
+function run_mc_mld_bf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_mld_bf is being depreciated in favor of solve_mc_mld, please update your code accordingly"
+    return solve_mc_mld(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mc_mld_uc"
+function run_mc_mld_uc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_mld_uc is being depreciated in favor of solve_mc_mld_uc, please update your code accordingly"
+    return solve_mc_mld_uc(data, model_type, solver; kwargs...)
 end

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -1,18 +1,12 @@
-"OPF with ACPPowerModel"
-function run_ac_mc_opf(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
-    return run_mc_opf(data, ACPPowerModel, solver; kwargs...)
+"Solve Optimal Power Flow"
+function solve_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_opf; kwargs...)
 end
 
 
-"Optimal Power Flow"
-function run_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_opf; kwargs...)
-end
-
-
-"Run multinetwork optimal power flow problem"
-function run_mn_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mn_mc_opf; multinetwork=true, kwargs...)
+"Solve multinetwork optimal power flow problem"
+function solve_mn_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mn_mc_opf; multinetwork=true, kwargs...)
 end
 
 
@@ -410,4 +404,26 @@ function build_mn_mc_opf(pm::AbstractUBFModels)
     end
 
     objective_mc_min_fuel_cost(pm)
+end
+
+# Depreciated run_ functions (remove after ~4-6 months)
+
+"depreciation warning for run_ac_mc_opf"
+function run_ac_mc_opf(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
+    @warn "run_ac_mc_opf is being depreciated in favor of solve_mc_opf(data, ACPPowerModel, solver; kwargs...), please update your code accordingly"
+    return solve_mc_opf(data, ACPPowerModel, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mc_opf"
+function run_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_opf is being depreciated in favor of solve_mc_opf, please update your code accordingly"
+    return solve_mc_opf(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mn_mc_opf"
+function run_mn_mc_opf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mn_mc_opf is being depreciated in favor of solve_mn_mc_opf, please update your code accordingly"
+    return solve_mn_mc_opf(data, model_type, solver; kwargs...)
 end

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -1,12 +1,6 @@
-"on-load tap-changer OPF with ACPPowerModel"
-function run_ac_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
-    return run_mc_opf_oltc(data, ACPPowerModel, solver; kwargs...)
-end
-
-
-"on-load tap-changer OPF"
-function run_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_opf_oltc; kwargs...)
+"Solve on-load tap-changer OPF"
+function solve_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_opf_oltc; kwargs...)
 end
 
 
@@ -63,4 +57,19 @@ function build_mc_opf_oltc(pm::_PM.AbstractPowerModel)
     end
 
     objective_mc_min_fuel_cost(pm)
+end
+
+# Depreciated run_ functions (remove after ~4-6 months)
+
+"depreciation warning for run_ac_mc_opf_oltc"
+function run_ac_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
+    @warn "run_ac_mc_opf_oltc is being depreciated in favor of solve_mc_opf_oltc(data, ACPPowerModel, solver; kwargs...), please update your code accordingly"
+    return solve_mc_opf_oltc(data, ACPPowerModel, solver; kwargs...)
+end
+
+
+"depreciation warning for run_mc_opf_oltc"
+function run_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_opf_oltc is being depreciated in favor of solve_mc_opf_oltc, please update your code accordingly"
+    return solve_mc_opf_oltc(data, model_type, solver; kwargs...)
 end

--- a/src/prob/osw.jl
+++ b/src/prob/osw.jl
@@ -1,6 +1,12 @@
-""
-function _run_mc_osw(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, _build_mc_osw; kwargs...)
+"Solve optimal switching problem"
+function _solve_mc_osw(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, _build_mc_osw; kwargs...)
+end
+
+
+"Solve mixed-integer optimal switching problem"
+function _solve_mc_osw_mi(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, _build_mc_osw_mi; kwargs...)
 end
 
 
@@ -190,12 +196,6 @@ function _build_mc_osw(pm::_PM.AbstractIVRModel)
 end
 
 
-""
-function _run_mc_osw_mi(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, _build_mc_osw_mi; kwargs...)
-end
-
-
 "Constructor for Optimal Switching"
 function _build_mc_osw_mi(pm::_PM.AbstractPowerModel)
     variable_mc_bus_voltage(pm)
@@ -325,3 +325,17 @@ function _build_mc_osw_mi(pm::AbstractUBFModels)
     objective_mc_min_fuel_cost_switch(pm)
 end
 
+# Depreciated run_ functions (remove after ~4-6 months)
+
+"depreciation warning for _run_mc_osw"
+function _run_mc_osw(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
+    @warn "_run_mc_osw is being depreciated in favor of _solve_mc_osw, please update your code accordingly"
+    return _solve_mc_osw(data, model_type, solver; kwargs...)
+end
+
+
+"depreciation warning for _run_mc_osw_mi"
+function _run_mc_osw_mi(data::Union{Dict{String,<:Any}, String}, model_type::Type, solver; kwargs...)
+    @warn "_run_mc_osw_mi is being depreciated in favor of _solve_mc_osw_mi, please update your code accordingly"
+    return _solve_mc_osw_mi(data, model_type, solver; kwargs...)
+end

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -1,12 +1,6 @@
-"Power Flow problem with ACPPowerModel"
-function run_ac_mc_pf(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
-    return run_mc_pf(data, _PM.ACPPowerModel, solver; kwargs...)
-end
-
-
 "Power Flow Problem"
-function run_mc_pf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, build_mc_pf; kwargs...)
+function solve_mc_pf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mc_pf; kwargs...)
 end
 
 
@@ -207,4 +201,19 @@ function build_mc_pf(pm::AbstractUBFModels)
     for i in _PM.ids(pm, :transformer)
         constraint_mc_transformer_power(pm, i)
     end
+end
+
+# Deprecated run_ functions (remove in ~4-6 months)
+
+"Power Flow problem with ACPPowerModel"
+function run_ac_mc_pf(data::Union{Dict{String,<:Any},String}, solver; kwargs...)
+    @warn "run_ac_mc_pf is being depreciated in favor of solve_mc_pf(data, ACPPowerModel, solver; kwargs...), please update your code accordingly"
+    return solve_mc_pf(data, ACPPowerModel, solver; kwargs...)
+end
+
+
+"Power Flow Problem"
+function run_mc_pf(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "run_mc_pf is being depreciated in favor of solve_mc_pf, please update your code accordingly"
+    return solve_mc_pf(data, model_type, solver; kwargs...)
 end

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -1,6 +1,6 @@
-"test mc mn"
-function _run_mc_mn_opb(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
-    return run_mc_model(data, model_type, solver, _build_mc_mn_opb; ref_extensions=[_PM.ref_add_connected_components!], multinetwork=true, kwargs...)
+"solve test mn mc problem"
+function _solve_mn_mc_opb(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, _build_mc_mn_opb; ref_extensions=[_PM.ref_add_connected_components!], multinetwork=true, kwargs...)
 end
 
 
@@ -15,4 +15,12 @@ function _build_mc_mn_opb(pm::_PM.AbstractPowerModel)
     end
 
     objective_mc_min_fuel_cost(pm)
+end
+
+# Depreciated run_ functions (remove in ~4-6 months)
+
+"depreciation warning for _run_mc_mn_opb"
+function _run_mc_mn_opb(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    @warn "_run_mc_mn_opb is being depreciated in favor of _solve_mn_mc_opb, please update your code accordingly"
+    return _solve_mn_mc_opb(data, model_type, solver; kwargs...)
 end

--- a/test/data_model.jl
+++ b/test/data_model.jl
@@ -19,7 +19,7 @@
 
         add_vbase_default!(eng, "sourcebus", 1)
 
-        result = run_mc_opf(eng, ACPPowerModel, ipopt_solver)
+        result = solve_mc_opf(eng, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0150; atol=1e-4)
@@ -41,7 +41,7 @@
         add_shunt!(eng2, "cap", "loadbus2", [1,2,3,4]; bs=diagm(0=>fill(1, 3)))
 
         # TODO this test is unstable with Julia 1.5, need to change the data model to fix it
-        # result2 = run_mc_opf(eng2, ACRPowerModel, ipopt_solver)
+        # result2 = solve_mc_opf(eng2, ACRPowerModel, ipopt_solver)
 
         # @test result2["termination_status"] == LOCALLY_SOLVED
         # @test isapprox(result2["objective"], -83.3003; atol=0.2)

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -3,7 +3,7 @@
 @testset "test pbs" begin
     @testset "case 3 unbalanced - ac pf pbs" begin
         mp_data = parse_file("../test/data/opendss/case3_unbalanced.dss")
-        result = run_mc_pf_pbs(mp_data, ACPPowerModel, ipopt_solver)
+        result = solve_mc_pf_pbs(mp_data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1e-4)

--- a/test/delta_gens.jl
+++ b/test/delta_gens.jl
@@ -37,10 +37,10 @@
 
         # check ACP and ACR
         for form in [ACPPowerModel, ACRPowerModel, IVRPowerModel]
-            sol_1 = run_mc_opf(eng_1, form, ipopt_solver)
+            sol_1 = solve_mc_opf(eng_1, form, ipopt_solver)
             @test sol_1["termination_status"] == LOCALLY_SOLVED
 
-            sol_2 = run_mc_opf(eng_2, form, ipopt_solver)
+            sol_2 = solve_mc_opf(eng_2, form, ipopt_solver)
             @test sol_2["termination_status"] == LOCALLY_SOLVED
 
             # check that gens are equivalent to the loads

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -3,7 +3,7 @@
 @testset "test loadmodels pf" begin
     @testset "loadmodels connection variations" begin
         pmd = parse_file("../test/data/opendss/case3_lm_1230.dss")
-        sol = run_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
         # voltage magnitude at load bus
         @test isapprox(vm(sol, "loadbus"), [0.999993, 0.999992, 0.999993], atol=1E-5)
         # single-phase delta loads
@@ -22,7 +22,7 @@
     end
     @testset "loadmodels 1/2/5 in acp pf" begin
         pmd = parse_file("../test/data/opendss/case3_lm_models.dss")
-        sol = run_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
         # voltage magnitude at load bus
         @test isapprox(vm(sol, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)
         # delta and wye single-phase load models
@@ -49,7 +49,7 @@
     end
     @testset "loadmodels 1/2/5 in acr pf" begin
         pmd = parse_file("../test/data/opendss/case3_lm_models.dss")
-        sol = run_mc_pf(pmd, ACRPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(pmd, ACRPowerModel, ipopt_solver; make_si=false)
         # voltage magnitude at load bus
         @test isapprox(calc_vm_acr(sol, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)
         # delta and wye single-phase load models
@@ -76,7 +76,7 @@
     end
     @testset "loadmodels 1/2/5 in ivr pf" begin
         pmd = parse_file("../test/data/opendss/case3_lm_models.dss")
-        sol = run_mc_pf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
         # voltage magnitude at load bus
         @test isapprox(calc_vm_acr(sol, "loadbus"), [0.83072, 0.99653, 1.0059], atol=1.5E-4)
         # delta and wye single-phase load models

--- a/test/mld.jl
+++ b/test/mld.jl
@@ -7,7 +7,7 @@
     ut_trans_2w_yy = PowerModelsDistribution.parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
 
     @testset "5-bus acp mld" begin
-        result = run_mc_mld(case5, ACPPowerModel, ipopt_solver)
+        result = solve_mc_mld(case5, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.1705; atol = 1e-4)
@@ -18,7 +18,7 @@
     end
 
     @testset "5-bus storage acp mld" begin
-        result = run_mc_mld(case5_strg, ACPPowerModel, ipopt_solver)
+        result = solve_mc_mld(case5_strg, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.1775; atol=1e-2)
@@ -27,7 +27,7 @@
     end
 
     @testset "5-bus nfa mld" begin
-        result = run_mc_mld(case5, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(case5, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol = 1e-4)
@@ -36,7 +36,7 @@
     end
 
     @testset "5-bus storage nfa mld" begin
-        result = run_mc_mld(case5_strg, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(case5_strg, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1e-4)
@@ -46,7 +46,7 @@
 
     @testset "5-bus mn acp mld" begin
         case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-        result = run_mn_mc_mld_simple(case5_mn, ACPPowerModel, ipopt_solver)
+        result = solve_mn_mc_mld_simple(case5_mn, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1.0e-4)
@@ -57,7 +57,7 @@
 
     @testset "5-bus mn storage acp mld" begin
         case5_strg_mn = InfrastructureModels.replicate(case5_strg, 3, Set(["per_unit"]))
-        result = run_mn_mc_mld_simple(case5_strg_mn, ACPPowerModel, ipopt_solver)
+        result = solve_mn_mc_mld_simple(case5_strg_mn, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1.0e-4)
@@ -66,7 +66,7 @@
 
     @testset "5-bus mn nfa mld" begin
         case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-        result = run_mn_mc_mld_simple(case5_mn, NFAPowerModel, ipopt_solver)
+        result = solve_mn_mc_mld_simple(case5_mn, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1.0e-4)
@@ -75,7 +75,7 @@
 
     @testset "5-bus mn storage nfa mld" begin
         case5_strg_mn = InfrastructureModels.replicate(case5_strg, 3, Set(["per_unit"]))
-        result = run_mn_mc_mld_simple(case5_strg_mn, NFAPowerModel, ipopt_solver)
+        result = solve_mn_mc_mld_simple(case5_strg_mn, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1.0e-4)
@@ -84,7 +84,7 @@
 
     @testset "5-bus mn lpubfdiag mld" begin
         case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-        result = run_mn_mc_mld_simple(case5_mn, LPUBFDiagPowerModel, ipopt_solver)
+        result = solve_mn_mc_mld_simple(case5_mn, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol=1.0e-4)
@@ -93,7 +93,7 @@
 
     @testset "3-bus nfa mld" begin
         mp_data = PM.parse_file("../test/data/matpower/case3_ml.m"); make_multiconductor!(mp_data, 3)
-        result = run_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 24.9; atol = 1e-1)
@@ -103,7 +103,7 @@
 
     @testset "3-bus shunt nfa mld" begin
         mp_data = PM.parse_file("../test/data/matpower/case3_ml_s.m"); make_multiconductor!(mp_data, 3)
-        result = run_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 22.2; atol = 1e-1)
@@ -113,7 +113,7 @@
 
     @testset "3-bus line charge nfa mld" begin
         mp_data = PM.parse_file("../test/data/matpower/case3_ml_lc.m"); make_multiconductor!(mp_data, 3)
-        result = run_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 43.8; atol = 1e-1)
@@ -122,7 +122,7 @@
     end
 
     @testset "transformer nfa mld" begin
-        result = run_mc_mld(ut_trans_2w_yy, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(ut_trans_2w_yy, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.411, atol = 1e-3)
@@ -130,19 +130,17 @@
     end
 
     @testset "5-bus lpubfdiag mld" begin
-        result = run_mc_mld(case5, LPUBFDiagPowerModel, ipopt_solver)
+        result = solve_mc_mld(case5, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.1557; atol = 1e-4)
 
         @test isapprox(result["solution"]["load"]["1"]["status"], 1.000; atol = 1e-3)
-
-        @test_throws(TESTLOG, MethodError, run_mc_mld_bf(case5, NFAPowerModel, ipopt_solver))
     end
 
     @testset "3-bus lpubfdiag mld" begin
 
-        result = run_mc_mld(case3_ml, LPUBFDiagPowerModel, ipopt_solver)
+        result = solve_mc_mld(case3_ml, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 24.98; atol = 1e-1)
@@ -151,7 +149,7 @@
     end
 
     @testset "transformer case" begin
-        result = run_mc_mld(ut_trans_2w_yy, LPUBFDiagPowerModel, ipopt_solver)
+        result = solve_mc_mld(ut_trans_2w_yy, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.431; atol=1e-3)
@@ -159,7 +157,7 @@
     end
 
     @testset "5-bus acp mld_uc" begin
-        result = run_mc_mld_uc(case5, ACPPowerModel, juniper_solver)
+        result = solve_mc_mld_uc(case5, ACPPowerModel, juniper_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.338; atol=1e-3)
@@ -168,7 +166,7 @@
     end
 
     @testset "5-bus nfa mld_uc" begin
-        result = run_mc_mld_uc(case5, NFAPowerModel, juniper_solver)
+        result = solve_mc_mld_uc(case5, NFAPowerModel, juniper_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (i, gen) in result["solution"]["gen"]

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -3,7 +3,7 @@
 @testset "test multinetwork" begin
     @testset "3-bus balanced multinetwork nfa opb" begin
         eng_ts = parse_file("../test/data/opendss/case3_balanced.dss"; time_series="daily")
-        result_mn = PowerModelsDistribution._run_mc_mn_opb(eng_ts, NFAPowerModel, ipopt_solver)
+        result_mn = PowerModelsDistribution._solve_mn_mc_opb(eng_ts, NFAPowerModel, ipopt_solver)
 
         @test result_mn["termination_status"] == LOCALLY_SOLVED
     end

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -11,7 +11,7 @@
         make_multiconductor!(case30, 3)
 
         @testset "5-bus matpower acp opf" begin
-            result = run_mc_opf(case5, ACPPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 45522.096; atol=1e-1)
@@ -21,7 +21,7 @@
         end
 
         @testset "5-bus matpower acr opf" begin
-            result = run_mc_opf(case5, ACRPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 45522.096; atol=1e-1)
@@ -33,7 +33,7 @@
 
         @testset "5-bus matpower mn acp mld" begin
             case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-            result = run_mn_mc_opf(case5_mn, ACPPowerModel, ipopt_solver)
+            result = solve_mn_mc_opf(case5_mn, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 45522.096*3; atol=1e-1)
@@ -44,7 +44,7 @@
 
         @testset "5-bus matpower mn acr mld" begin
             case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-            result = run_mn_mc_opf(case5_mn, ACRPowerModel, ipopt_solver)
+            result = solve_mn_mc_opf(case5_mn, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 45522.096*3; atol=1e-1)
@@ -56,14 +56,14 @@
 
         @testset "5-bus storage matpower mn acp mld" begin
             case5_strg_mn = InfrastructureModels.replicate(case5_strg, 3, Set(["per_unit"]))
-            result = run_mn_mc_opf(case5_strg_mn, ACPPowerModel, ipopt_solver)
+            result = solve_mn_mc_opf(case5_strg_mn, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test result["objective"] >= 45522.096*3
         end
 
         @testset "30-bus matpower acp opf" begin
-            result = run_mc_opf(case30, ACPPowerModel, ipopt_solver)
+            result = solve_mc_opf(case30, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 614.007; atol=1e-1)
@@ -73,7 +73,7 @@
         end
 
         @testset "30-bus matpower acr opf" begin
-            result = run_mc_opf(case30, ACRPowerModel, ipopt_solver)
+            result = solve_mc_opf(case30, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 614.007; atol=1e-1)
@@ -84,14 +84,14 @@
         end
 
         @testset "30-bus matpower dcp opf" begin
-            result = run_mc_opf(case30, DCPPowerModel, ipopt_solver)
+            result = solve_mc_opf(case30, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 566.112; atol=1e-1)
         end
 
         @testset "30-bus matpower nfa opf" begin
-            result = run_mc_opf(case30, NFAPowerModel, ipopt_solver)
+            result = solve_mc_opf(case30, NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 458.006; atol=1e-1)
@@ -103,7 +103,7 @@
         case5_phase_drop = parse_file("../test/data/opendss/case5_phase_drop.dss")
 
         @testset "4-bus phase drop acp opf" begin
-            result = run_mc_opf(case4_phase_drop, ACPPowerModel, ipopt_solver, make_si=false)
+            result = solve_mc_opf(case4_phase_drop, ACPPowerModel, ipopt_solver, make_si=false)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.0182595; atol=1e-4)
@@ -113,7 +113,7 @@
         end
 
         @testset "4-bus phase drop acr opf" begin
-            result = run_mc_opf(case4_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
+            result = solve_mc_opf(case4_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.0182595; atol=1e-4)
@@ -123,7 +123,7 @@
         end
 
         @testset "5-bus phase drop acp opf" begin
-            result = run_mc_opf(case5_phase_drop, ACPPowerModel, ipopt_solver; make_si=false)
+            result = solve_mc_opf(case5_phase_drop, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.0599389; atol=1e-4)
@@ -133,7 +133,7 @@
         end
 
         @testset "5-bus phase drop acr opf" begin
-            result = run_mc_opf(case5_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
+            result = solve_mc_opf(case5_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.0599400; atol = 1e-4)
@@ -143,14 +143,14 @@
         end
 
         @testset "5-bus phase drop dcp opf" begin
-            result = run_mc_opf(case5_phase_drop, DCPPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5_phase_drop, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.054; atol=1e-4)
         end
 
         @testset "5-bus phase drop nfa opf" begin
-            result = run_mc_opf(case5_phase_drop, NFAPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5_phase_drop, NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.054; atol=1e-4)
@@ -160,7 +160,7 @@
     @testset "test opendss opf" begin
         @testset "2-bus diagonal acp opf" begin
             pmd = parse_file("../test/data/opendss/case2_diag.dss")
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -173,7 +173,7 @@
 
         @testset "3-bus balanced acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced.dss")
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -188,7 +188,7 @@
 
         @testset "3-bus unbalanced acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced.dss")
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -205,7 +205,7 @@
 
         @testset "3-bus unbalanced isc acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced_isc.dss")
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sol["objective"], 0.0185; atol=1e-4)
@@ -214,7 +214,7 @@
         @testset "3-bus balanced pv acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced_pv.dss")
 
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test sum(sol["solution"]["voltage_source"]["source"]["pg"] * sol["solution"]["settings"]["sbase"]) < 0.0
@@ -225,7 +225,7 @@
 
         @testset "3-bus unbalanced single-phase pv acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced_1phase-pv.dss")
-            sol = run_mc_opf(pmd, ACPPowerModel, ipopt_solver)
+            sol = solve_mc_opf(pmd, ACPPowerModel, ipopt_solver)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -238,7 +238,7 @@
 
         @testset "3-bus balanced capacitor acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced_cap.dss")
-            sol = run_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -248,7 +248,7 @@
 
         @testset "3w transformer nfa opf" begin
             mp_data = parse_file("../test/data/opendss/ut_trans_3w_dyy_1.dss")
-            result = run_mc_opf(mp_data, NFAPowerModel, ipopt_solver)
+            result = solve_mc_opf(mp_data, NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0.616; atol=1e-3)
@@ -260,16 +260,16 @@
             pmd_eng = parse_file("../test/data/opendss/case3_unbalanced.dss")
             pmd_math = transform_data_model(pmd_eng)
 
-            sol_ivr = run_mc_opf(pmd_math, IVRPowerModel, ipopt_solver)
-            sol_acr = run_mc_opf(pmd_math, ACRPowerModel, ipopt_solver)
+            sol_ivr = solve_mc_opf(pmd_math, IVRPowerModel, ipopt_solver)
+            sol_acr = solve_mc_opf(pmd_math, ACRPowerModel, ipopt_solver)
 
             pmd_math["bus"]["4"]["vm_start"] = pmd_math["bus"]["4"]["vm"]
             pmd_math["bus"]["4"]["va_start"] = pmd_math["bus"]["4"]["va"]
             pmd_math["bus"]["2"]["vm_start"] = [0.9959, 0.9959, 0.9959]
             pmd_math["bus"]["2"]["va_start"] = [0.00, -2.0944, 2.0944]
 
-            sol_ivr_with_start = run_mc_opf(pmd_math, IVRPowerModel, ipopt_solver)
-            sol_acr_with_start = run_mc_opf(pmd_math, ACRPowerModel, ipopt_solver)
+            sol_ivr_with_start = solve_mc_opf(pmd_math, IVRPowerModel, ipopt_solver)
+            sol_acr_with_start = solve_mc_opf(pmd_math, ACRPowerModel, ipopt_solver)
 
             @test isapprox(sol_ivr["objective"], sol_ivr_with_start["objective"]; atol=1e-5)
             @test isapprox(sol_acr["objective"], sol_acr_with_start["objective"]; atol=1e-5)
@@ -298,7 +298,7 @@
                                 "pmin"          => [-Inf],
                                 "ncost"         => 2
                                 )
-            sol = run_mc_opf(data, ACPPowerModel, ipopt_solver)
+            sol = solve_mc_opf(data, ACPPowerModel, ipopt_solver)
             @test sol["termination_status"] == LOCALLY_SOLVED
         end
     end

--- a/test/opf_bf.jl
+++ b/test/opf_bf.jl
@@ -6,7 +6,7 @@
 
     @testset "test linearised distflow opf_bf" begin
         @testset "5-bus lpubfdiag opf_bf" begin
-            result = run_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 44880; atol = 1e0)
@@ -18,7 +18,7 @@
 
         @testset "5-bus mn lpubfdiag opf_bf" begin
             case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-            result = run_mn_mc_opf(case5_mn, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mn_mc_opf(case5_mn, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 44880.0*3; atol = 1e0)
@@ -26,7 +26,7 @@
 
         @testset "3-bus balanced lpubfdiag opf_bf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced.dss")
-            sol = run_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["pg"] * sol["solution"]["settings"]["sbase"]), 0.0183456; atol=2e-3)
@@ -35,7 +35,7 @@
 
         @testset "3-bus unbalanced lpubfdiag opf_bf" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced.dss")
-            sol = run_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["pg"] * sol["solution"]["settings"]["sbase"]), 0.0214812; atol=2e-3)
@@ -43,7 +43,7 @@
         end
         @testset "3-bus unbalanced lpubfdiag opf_bf with only two terminals on load bus" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced_missingedge.dss")
-            sol = run_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver)
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test norm(sol["solution"]["bus"]["loadbus"]["w"]-[0.92234, 0.95778], Inf) <= 1E-4
         end
@@ -51,7 +51,7 @@
 
     @testset "test linearised distflow opf_bf in diagonal matrix form" begin
         @testset "5-bus lpdiagubf opf_bf" begin
-            result = run_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 44880; atol = 1e0)
@@ -60,7 +60,7 @@
 
     @testset "test linearised distflow opf_bf in full matrix form" begin
         @testset "5-bus lpfullubf opf_bf" begin
-            result = run_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_opf(case5, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 44880; atol = 1e0)
@@ -108,7 +108,7 @@
 
     @testset "test sdp distflow opf_bf" begin
         @testset "3-bus SDPUBF opf_bf" begin
-            result = run_mc_opf(data, SDPUBFPowerModel, scs_solver)
+            result = solve_mc_opf(data, SDPUBFPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 21.48; atol = 1e-2)
@@ -118,7 +118,7 @@
     # TODO track down why this problem is infeasible in the matrix form (extra Pg,Qg variables?)
     # @testset "test sdp distflow opf_bf in full matrix form" begin
     #     @testset "3-bus SDPUBFKCLMX opf_bf" begin
-    #         result = run_mc_opf(data, SDPUBFKCLMXPowerModel, scs_solver)
+    #         result = solve_mc_opf(data, SDPUBFKCLMXPowerModel, scs_solver)
 
     #         @test result["termination_status"] == OPTIMAL
     #         @test isapprox(result["objective"], 21.48; atol = 1e-2)
@@ -128,13 +128,13 @@
 
     @testset "test soc distflow opf_bf" begin
         @testset "3-bus SOCNLPUBF opf_bf" begin
-            result = run_mc_opf(data, SOCNLPUBFPowerModel, ipopt_solver)
+            result = solve_mc_opf(data, SOCNLPUBFPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 21.179; atol = 1e-1)
         end
         # @testset "3-bus SOCConicUBF opf_bf" begin
-        #     result = run_mc_opf(data, SOCConicUBFPowerModel, scs_solver)
+        #     result = solve_mc_opf(data, SOCConicUBFPowerModel, scs_solver)
         #
         #     @test result["termination_status"] == ALMOST_OPTIMAL
         #     @test isapprox(result["objective"], 21.17; atol = 1e-2)

--- a/test/opf_iv.jl
+++ b/test/opf_iv.jl
@@ -4,7 +4,7 @@
     @testset "test IVR opf_iv" begin
         @testset "2-bus diagonal acp opf" begin
             pmd = parse_file("../test/data/opendss/case2_diag.dss")
-            sol = run_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sol["objective"], 0.018208969542066918; atol = 1e-4)
@@ -15,7 +15,7 @@
 
         @testset "3-bus balanced acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced.dss")
-            sol = run_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sol["objective"], 0.018345004773175046; atol = 1e-4)
@@ -26,7 +26,7 @@
 
         @testset "3-bus unbalanced acp opf" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced.dss")
-            sol = run_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
+            sol = solve_mc_opf(pmd, IVRPowerModel, ipopt_solver; make_si=false)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sol["objective"], 0.021481176584287; atol = 1e-4)
@@ -40,7 +40,7 @@
             case5 = PM.parse_file("../test/data/matpower/case5.m")
             make_multiconductor!(case5, 3)
             case5_mn = InfrastructureModels.replicate(case5, 3, Set(["per_unit"]))
-            result = run_mn_mc_opf(case5_mn, IVRPowerModel, ipopt_solver)
+            result = solve_mn_mc_opf(case5_mn, IVRPowerModel, ipopt_solver)
             @test result["termination_status"] == LOCALLY_SOLVED
         end
     end

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -8,7 +8,7 @@
     case_mxshunt = parse_file("../test/data/opendss/case_mxshunt.dss")
 
     @testset "2-bus diagonal acp pf" begin
-        sol = run_mc_pf(case2_diag, ACPPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case2_diag, ACPPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -20,7 +20,7 @@
     end
 
     @testset "2-bus diagonal acr pf" begin
-        sol = run_mc_pf(case2_diag, ACRPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case2_diag, ACRPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -32,7 +32,7 @@
     end
 
     @testset "3-bus balanced acp pf" begin
-        sol = run_mc_pf(case3_balanced, ACPPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case3_balanced, ACPPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -46,7 +46,7 @@
     end
 
     @testset "3-bus balanced acr pf" begin
-        sol = run_mc_pf(case3_balanced, ACRPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case3_balanced, ACRPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -60,10 +60,10 @@
     end
 
     @testset "3-bus balanced no linecode basefreq defined acp pf" begin
-        sol = run_mc_pf(case3_balanced, ACPPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case3_balanced, ACPPowerModel, ipopt_solver)
 
         pmd2 = parse_file("../test/data/opendss/case3_balanced_basefreq.dss")
-        sol2 = run_mc_pf(pmd2, ACPPowerModel, ipopt_solver)
+        sol2 = solve_mc_pf(pmd2, ACPPowerModel, ipopt_solver)
 
         @test all(all(isapprox.(bus["vm"], sol2["solution"]["bus"][i]["vm"]; atol=1e-8)) for (i, bus) in sol["solution"]["bus"])
         @test all(all(isapprox.(bus["va"], sol2["solution"]["bus"][i]["va"]; atol=1e-8)) for (i, bus) in sol["solution"]["bus"])
@@ -71,7 +71,7 @@
     end
 
     @testset "3-bus unbalanced acp pf" begin
-        sol = run_mc_pf(case3_unbalanced, ACPPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(case3_unbalanced, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -87,7 +87,7 @@
     end
 
     @testset "3-bus unbalanced acr pf" begin
-        sol = run_mc_pf(case3_unbalanced, ACRPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(case3_unbalanced, ACRPowerModel, ipopt_solver; make_si=false)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -104,7 +104,7 @@
 
     @testset "3-bus unbalanced w/ asymmetric linecode & phase order swap acp pf" begin
         pmd = parse_file("../test/data/opendss/case3_unbalanced_assym_swap.dss")
-        sol = run_ac_mc_pf(pmd, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(pmd, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -113,7 +113,7 @@
     end
 
     @testset "5-bus phase drop acp pf" begin
-        result = run_mc_pf(case5_phase_drop, ACPPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_pf(case5_phase_drop, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -121,7 +121,7 @@
     end
 
     @testset "5-bus phase drop acr pf" begin
-        sol = run_mc_pf(case5_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(case5_phase_drop, ACRPowerModel, ipopt_solver; make_si=false)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -129,20 +129,20 @@
     end
 
     @testset "matrix branch shunts acp pf" begin
-        sol = run_ac_mc_pf(case_mxshunt, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(case_mxshunt, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test all(isapprox.(sol["solution"]["bus"]["loadbus"]["vm"], [0.987399, 0.981300, 1.003536]; atol=1E-6))
     end
 
     @testset "matrix branch shunts acr pf" begin
-        sol = run_mc_pf(case_mxshunt, ACRPowerModel, ipopt_solver; make_si=false)
+        sol = solve_mc_pf(case_mxshunt, ACRPowerModel, ipopt_solver; make_si=false)
 
         @test all(isapprox.(calc_vm_acr(sol, "loadbus"), [0.987399, 0.981299, 1.003537]; atol=1E-6))
     end
 
     @testset "virtual sourcebus creation acp pf" begin
         pmd = parse_file("../test/data/opendss/virtual_sourcebus.dss"; data_model=MATHEMATICAL)
-        result = run_ac_mc_pf(pmd, ipopt_solver)
+        result = solve_mc_pf(pmd, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -151,7 +151,7 @@
     end
 
     @testset "2-bus diagonal ivr pf" begin
-        sol = run_mc_pf(case2_diag, IVRPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case2_diag, IVRPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 
@@ -160,7 +160,7 @@
     end
 
     @testset "3-bus balanced ivr pf" begin
-        sol = run_mc_pf(case3_balanced, IVRPowerModel, ipopt_solver)
+        sol = solve_mc_pf(case3_balanced, IVRPowerModel, ipopt_solver)
 
         @test sol["termination_status"] == LOCALLY_SOLVED
 

--- a/test/pf_bf.jl
+++ b/test/pf_bf.jl
@@ -5,7 +5,7 @@
         @testset "5-bus lpubfdiag opf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             make_multiconductor!(mp_data, 3)
-            result = run_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0; atol = 1e0)
@@ -17,7 +17,7 @@
 
         @testset "3-bus balanced lpubfdiag pf_bf" begin
             pmd = parse_file("../test/data/opendss/case3_balanced.dss"; data_model=MATHEMATICAL)
-            sol = run_mc_pf(pmd, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_pf(pmd, LPUBFDiagPowerModel, ipopt_solver)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0183456; atol=2e-3)
@@ -26,7 +26,7 @@
 
         @testset "3-bus unbalanced lpubfdiag pf_bf" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced.dss"; data_model=MATHEMATICAL)
-            sol = run_mc_pf(pmd, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_pf(pmd, LPUBFDiagPowerModel, ipopt_solver)
 
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0214812; atol=2e-3)
@@ -38,7 +38,7 @@
         @testset "5-bus lpdiagubf pf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             make_multiconductor!(mp_data, 3)
-            result = run_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0; atol = 1e0)
@@ -49,7 +49,7 @@
         @testset "5-bus lpfullubf pf_bf" begin
             mp_data = PowerModels.parse_file("../test/data/matpower/case5.m")
             make_multiconductor!(mp_data, 3)
-            result = run_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
+            result = solve_mc_pf(mp_data, LPUBFDiagPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0; atol = 1e0)
@@ -82,7 +82,7 @@
 
     @testset "test sdp distflow pf_bf" begin
         @testset "3-bus SDPUBF pf_bf" begin
-            result = run_mc_pf(data, SDPUBFPowerModel, scs_solver)
+            result = solve_mc_pf(data, SDPUBFPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -91,7 +91,7 @@
 
     # @testset "test sdp distflow pf_bf in full matrix form" begin
     #     @testset "3-bus SDPUBFKCLMX pf_bf" begin
-    #         result = run_mc_pf(data, SDPUBFKCLMXPowerModel, scs_solver)
+    #         result = solve_mc_pf(data, SDPUBFKCLMXPowerModel, scs_solver)
     #
     #         @test result["termination_status"] == OPTIMAL
     #         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -101,13 +101,13 @@
 
     @testset "test soc distflow pf_bf" begin
         @testset "3-bus SOCNLPUBF pf_bf" begin
-            result = run_mc_pf(data, SOCNLPUBFPowerModel, ipopt_solver)
+            result = solve_mc_pf(data, SOCNLPUBFPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0; atol = 1e-1)
         end
         @testset "3-bus SOCConicUBF pf_bf" begin
-            result = run_mc_pf(data, SOCConicUBFPowerModel, scs_solver)
+            result = solve_mc_pf(data, SOCConicUBFPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 0; atol = 1e-2)

--- a/test/shunt.jl
+++ b/test/shunt.jl
@@ -10,10 +10,10 @@
     data_diag_shunt = deepcopy(data)
     data_diag_shunt["shunt"]["1"]["bs"] = shunt["bs"].*[c==d for c in 1:3, d in 1:3]
 
-    sol_acp_diag = run_mc_pf(data_diag_shunt, ACPPowerModel, ipopt_solver)
-    sol_acp = run_mc_pf(data, ACPPowerModel, ipopt_solver)
-    sol_acr = run_mc_pf(data, ACRPowerModel, ipopt_solver)
-    sol_iv = run_mc_pf(data, IVRPowerModel, ipopt_solver)
+    sol_acp_diag = solve_mc_pf(data_diag_shunt, ACPPowerModel, ipopt_solver)
+    sol_acp = solve_mc_pf(data, ACPPowerModel, ipopt_solver)
+    sol_acr = solve_mc_pf(data, ACRPowerModel, ipopt_solver)
+    sol_iv = solve_mc_pf(data, IVRPowerModel, ipopt_solver)
 
     # check the results are different with only diagonal elements
     @test(!isapprox(sol_acp["solution"]["bus"]["2"]["vm"], sol_acp_diag["solution"]["bus"]["2"]["vm"]))

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -5,7 +5,7 @@
     make_multiconductor!(mp_data, 3)
 
     @testset "5-bus storage acp opf" begin
-        result = run_mc_opf(mp_data, ACPPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_opf(mp_data, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 52299.2; atol = 1e0)
@@ -18,7 +18,7 @@
     end
 
     @testset "5-bus storage arc opf" begin
-        result = run_mc_opf(mp_data, ACRPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_opf(mp_data, ACRPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 52299.2; atol = 1e0)
@@ -31,7 +31,7 @@
     end
 
     @testset "5-bus storage dcp opf" begin
-        result = run_mc_opf(mp_data, DCPPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_opf(mp_data, DCPPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 52059.6; atol = 1e0)
@@ -44,7 +44,7 @@
     end
 
     @testset "5-bus storage lpubfdiag opf" begin
-        result = run_mc_opf(mp_data, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_opf(mp_data, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 43170.0; atol = 1e0)
@@ -57,7 +57,7 @@
     end
 
     @testset "5-bus storage nfa opf" begin
-        result = run_mc_opf(mp_data, NFAPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_opf(mp_data, NFAPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 43169.9; atol = 1e0)
@@ -75,20 +75,20 @@ end
     eng = parse_file("../test/data/opendss/case3_balanced_battery.dss")
 
     @testset "3-bus balanced battery acp pf" begin
-        result = run_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test all(isapprox.(result["solution"]["bus"]["primary"]["vm"], 0.98697; atol=1e-5))
     end
     @testset "3-bus balanced battery acr pf" begin
-        result = run_mc_pf(eng, ACRPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_pf(eng, ACRPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test all(isapprox.(calc_vm_acr(result, "primary"), 0.98697; atol=1e-5))
     end
     #= TODO Rewrite failing test (passes locally)
     @testset "3-bus balanced battery lpubfdiag pf" begin
-        result = run_mc_pf(eng, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
+        result = solve_mc_pf(eng, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test all(isapprox.(result["solution"]["bus"]["primary"]["w"], 0.99767; atol=2e-3))
@@ -101,7 +101,7 @@ end
     make_multiconductor!(mp_data, 3)
 
     @testset "5-bus mld storage acp mld" begin
-        result = run_mc_mld(mp_data, ACPPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 137.17; atol = 1e-2)
@@ -111,7 +111,7 @@ end
     end
 
     @testset "5-bus mld storage acr mld" begin
-        result = run_mc_mld(mp_data, ACRPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 137.17; atol = 1e-2)
@@ -121,7 +121,7 @@ end
     end
 
     @testset "5-bus mld storage lpubfdiag mld" begin
-        result = run_mc_mld(mp_data, LPUBFDiagPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, LPUBFDiagPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 136.94; atol = 1e-1)
@@ -131,7 +131,7 @@ end
     end
 
     @testset "5-bus mld storage nfa mld" begin
-        result = run_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
+        result = solve_mc_mld(mp_data, NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 131.7; atol = 1e-1)

--- a/test/switch.jl
+++ b/test/switch.jl
@@ -5,7 +5,7 @@ eng["switch"]["ohline"]["length"] = 1.0
 
 @testset "test switch opf" begin
     @testset "3-bus balanced switch closed opf acp" begin
-       result = run_mc_opf(eng, ACPPowerModel, ipopt_solver_adaptive; make_si=false)
+       result = solve_mc_opf(eng, ACPPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, va, vm) in zip(["sourcebus", "primary", "loadbus"], [0.0, -0.032919, -0.0663864], [0.9959, 0.986973, 0.976606])
@@ -15,7 +15,7 @@ eng["switch"]["ohline"]["length"] = 1.0
     end
 
     @testset "3-bus balanced switch closed opf acr" begin
-        result = run_mc_opf(eng, ACRPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_opf(eng, ACRPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, va, vm) in zip(["sourcebus", "primary", "loadbus"], [0.0, -0.032919, -0.066387], [0.995899, 0.9869727, 0.9766053])
@@ -25,7 +25,7 @@ eng["switch"]["ohline"]["length"] = 1.0
     end
 
     @testset "3-bus balanced switch closed opf ivr" begin
-        result = run_mc_opf(eng, IVRPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_opf(eng, IVRPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, va, vm) in zip(["sourcebus", "primary", "loadbus"], [0.0, -0.032919, -0.066387], [0.995899, 0.9869727, 0.9766053])
@@ -35,14 +35,14 @@ eng["switch"]["ohline"]["length"] = 1.0
     end
 
     @testset "3-bus balanced switch closed opf nfa" begin
-        result = run_mc_opf(eng, NFAPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_opf(eng, NFAPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test all(isapprox.(result["solution"]["voltage_source"]["source"]["pg"], 6.0e-5; atol=1e-5))
     end
 
     @testset "3-bus balanced switch closed opf lpubfdiag" begin
-        result = run_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, vm) in zip(["sourcebus", "primary", "loadbus"], [0.9959, 0.987107, 0.976797])
@@ -53,7 +53,7 @@ end
 
 @testset "test switch pf" begin
     @testset "3-bus balanced switch closed pf acp" begin
-        result = run_mc_pf(eng, ACPPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_pf(eng, ACPPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -64,7 +64,7 @@ end
     end
 
     @testset "3-bus balanced switch closed pf acr" begin
-        result = run_mc_pf(eng, ACRPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_pf(eng, ACRPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -75,7 +75,7 @@ end
     end
 
     @testset "3-bus balanced switch closed pf ivr" begin
-        result = run_mc_pf(eng, IVRPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_pf(eng, IVRPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, va, vm) in zip(["sourcebus", "primary", "loadbus"], [0.0, -0.032919, -0.066387], [0.995899, 0.9869727, 0.9766053])
@@ -85,14 +85,14 @@ end
     end
 
     @testset "3-bus balanced switch closed pf nfa" begin
-        result = run_mc_pf(eng, NFAPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_pf(eng, NFAPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test all(isapprox.(result["solution"]["voltage_source"]["source"]["pg"], 6.0e-5; atol=1e-6))
     end
 
     @testset "3-bus balanced switch closed pf lpubfdiag" begin
-        result = run_mc_pf(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive; make_si=false)
+        result = solve_mc_pf(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive; make_si=false)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (bus, vm) in zip(["sourcebus", "primary", "loadbus"], [0.9959, 0.987107, 0.976797])
@@ -106,7 +106,7 @@ end
     eng["switch"]["ohline"]["state"] = OPEN
 
     @testset "3-bus balanced switch open mld acp" begin
-        result = run_mc_mld(eng, ACPPowerModel, ipopt_solver)
+        result = solve_mc_mld(eng, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (_,load) in result["solution"]["load"]
@@ -115,7 +115,7 @@ end
     end
 
     @testset "3-bus balanced switch open mld acr" begin
-        result = run_mc_mld(eng, ACRPowerModel, ipopt_solver_adaptive)
+        result = solve_mc_mld(eng, ACRPowerModel, ipopt_solver_adaptive)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (_,load) in result["solution"]["load"]
@@ -124,7 +124,7 @@ end
     end
 
     @testset "3-bus balanced switch open mld nfa" begin
-        result = run_mc_mld(eng, NFAPowerModel, ipopt_solver_adaptive)
+        result = solve_mc_mld(eng, NFAPowerModel, ipopt_solver_adaptive)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (_,load) in result["solution"]["load"]
@@ -133,7 +133,7 @@ end
     end
 
     @testset "3-bus balanced switch open mld lpubfdiag" begin
-        result = run_mc_mld(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive)
+        result = solve_mc_mld(eng, LPUBFDiagPowerModel, ipopt_solver_adaptive)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         for (_,load) in result["solution"]["load"]
@@ -146,7 +146,7 @@ end
     eng["switch"]["ohline"]["state"] = CLOSED
     make_lossless!(eng)
 
-    result = run_mc_opf(eng, ACPPowerModel, ipopt_solver_adaptive)
+    result = solve_mc_opf(eng, ACPPowerModel, ipopt_solver_adaptive)
 
     @test result["termination_status"] == LOCALLY_SOLVED
     @test all(result["solution"]["switch"]["ohline"]["psw_fr"] .== -result["solution"]["switch"]["ohline"]["psw_to"])

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -4,21 +4,21 @@
     @testset "test transformer acp pf" begin
         @testset "2w transformer acp pf yy" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87451, 0.8613, 0.85348], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-0.1, -120.4, 119.8], Inf) <= 0.1
         end
 
         @testset "2w transformer acp pf dy_lead" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lead.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87391, 0.86055, 0.85486], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[29.8, -90.4, 149.8], Inf) <= 0.1
         end
 
         @testset "2w transformer acp pf dy_lag" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lag.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.92092, 0.91012, 0.90059], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-30.0, -150.4, 89.8], Inf) <= 0.1
         end
@@ -27,21 +27,21 @@
     @testset "test transformer ivr pf" begin
         @testset "2w transformer ivr pf yy" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
-            sol = run_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87451, 0.8613, 0.85348], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-0.1, -120.4, 119.8], Inf) <= 0.1
         end
 
         @testset "2w transformer ivr pf dy_lead" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lead.dss")
-            sol = run_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87391, 0.86055, 0.85486], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[29.8, -90.4, 149.8], Inf) <= 0.1
         end
 
         @testset "2w transformer ivr pf dy_lag" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lag.dss")
-            sol = run_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, IVRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.92092, 0.91012, 0.90059], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-30.0, -150.4, 89.8], Inf) <= 0.1
         end
@@ -50,21 +50,21 @@
     @testset "test transformer acr pf" begin
         @testset "2w transformer acr pf yy" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_yy.dss")
-            sol = run_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87451, 0.8613, 0.85348], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-0.1, -120.4, 119.8], Inf) <= 0.1
         end
 
         @testset "2w transformer acr pf dy_lead" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lead.dss")
-            sol = run_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.87391, 0.86055, 0.85486], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[29.8, -90.4, 149.8], Inf) <= 0.1
         end
 
         @testset "2w transformer acr pf dy_lag" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lag.dss")
-            sol = run_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
+            sol = solve_mc_pf(eng, ACRPowerModel, ipopt_solver; solution_processors=[sol_polar_voltage!], make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.92092, 0.91012, 0.90059], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[-30.0, -150.4, 89.8], Inf) <= 0.1
         end
@@ -73,8 +73,8 @@
     @testset "2w transformer ac pf yy - banked transformers" begin
         eng1 = parse_file("../test/data/opendss/ut_trans_2w_yy_bank.dss")
         eng2 = parse_file("../test/data/opendss/ut_trans_2w_yy_bank.dss"; bank_transformers=false)
-        result1 = run_ac_mc_pf(eng1, ipopt_solver)
-        result2 = run_ac_mc_pf(eng2, ipopt_solver)
+        result1 = solve_mc_pf(eng1, ACPPowerModel, ipopt_solver)
+        result2 = solve_mc_pf(eng2, ACPPowerModel, ipopt_solver)
 
         @test result1["termination_status"] == LOCALLY_SOLVED
         @test result2["termination_status"] == LOCALLY_SOLVED
@@ -87,7 +87,7 @@
         @testset "3w transformer ac pf dyy - all non-zero"  begin
             file =
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_1.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.9318, 0.88828, 0.88581], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[30.1, -90.7, 151.2], Inf) <= 0.1
         end
@@ -95,7 +95,7 @@
         @testset "3w transformer ac pf dyy - some non-zero" begin
             file =
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_2.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
             #@test isapprox(vm(sol, eng, "3"), [0.93876, 0.90227, 0.90454], atol=1E-4)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.93876, 0.90227, 0.90454], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[31.6, -88.8, 153.3], Inf) <= 0.1
@@ -103,14 +103,14 @@
 
         @testset "3w transformer ac pf dyy - all zero" begin
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_3.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.97047, 0.93949, 0.946], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[30.6, -90.0, 151.9], Inf) <= 0.1
         end
 
         @testset "3w transformer ac pf dyy - %loadloss=0" begin
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_3_loadloss.dss")
-            sol = run_ac_mc_pf(eng, ipopt_solver; make_si=false)
+            sol = solve_mc_pf(eng, ACPPowerModel, ipopt_solver; make_si=false)
             @test norm(sol["solution"]["bus"]["3"]["vm"]-[0.969531, 0.938369, 0.944748], Inf) <= 1.5E-5
             @test norm(sol["solution"]["bus"]["3"]["va"]-[30.7, -90.0, 152.0], Inf) <= 0.1
         end
@@ -143,23 +143,23 @@
     @testset "linearized transformers" begin
         @testset "2w_dy_lead" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lead.dss")
-            sol = run_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
             @test norm(sol["solution"]["bus"]["3"]["w"]-[0.76674, 0.74840, 0.73846], Inf) <= 1E-4
         end
         @testset "3w_dyy_1" begin
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_1.dss")
-            sol = run_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
             @test norm(sol["solution"]["bus"]["3"]["w"]-[0.86095, 0.81344, 0.80480], Inf) <= 1E-4
         end
         @testset "3w_dyy_2" begin
             eng = parse_file("../test/data/opendss/ut_trans_3w_dyy_2.dss")
-            sol = run_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
+            sol = solve_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
             @test norm(sol["solution"]["bus"]["3"]["w"]-[0.87086, 0.83270, 0.83208], Inf) <= 1E-4
         end
         @testset "2w_dy_lead_small_series_impedance" begin
             eng = parse_file("../test/data/opendss/ut_trans_2w_dy_lead_small_series_impedance.dss", data_model=MATHEMATICAL)
-            sola = run_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
-            solb = run_mc_opf(eng, ACPPowerModel, ipopt_solver)
+            sola = solve_mc_opf(eng, LPUBFDiagPowerModel, ipopt_solver)
+            solb = solve_mc_opf(eng, ACPPowerModel, ipopt_solver)
             @test norm(sola["solution"]["bus"]["1"]["w"]-solb["solution"]["bus"]["1"]["vm"].^2, Inf) <= 1.2E-3
             @test norm(sola["solution"]["branch"]["1"]["pf"]-solb["solution"]["branch"]["1"]["pf"], Inf) <= 1E-3
         end


### PR DESCRIPTION
`run_` functions are depreciated in favor of `solve_`. Depreciation
warnings will remain for ~4-6 months before being removed
completely.

Updates InfrastructureModels to ~0.5.4 to add support for
`relax_integrality`.

Updates changelog and unit tests