### PR TITLE
FIX: single-phase buses and branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## staged
 
-- none
+- fix bug for acr, ivr, acp and lindist3flow forms, allowing elements with single phase terminals/connections
 
 ## v0.10.2
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -100,6 +100,8 @@ function constraint_mc_ohms_yt_from(pm::_PM.AbstractPowerModel, i::Int; nw::Int=
     t_idx = (i, t_bus, f_bus)
 
     G, B = _PM.calc_branch_y(branch)
+    if isa(G, Float64) G = [G] end
+    if isa(B, Float64) B = [B] end
 
     constraint_mc_ohms_yt_from(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], G, B, branch["g_fr"], branch["b_fr"])
 end
@@ -114,6 +116,8 @@ function constraint_mc_ohms_yt_to(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm
     t_idx = (i, t_bus, f_bus)
 
     G, B = _PM.calc_branch_y(branch)
+    if isa(G, Float64) G = [G] end
+    if isa(B, Float64) B = [B] end
 
     constraint_mc_ohms_yt_to(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], G, B, branch["g_to"], branch["b_to"])
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -100,10 +100,8 @@ function constraint_mc_ohms_yt_from(pm::_PM.AbstractPowerModel, i::Int; nw::Int=
     t_idx = (i, t_bus, f_bus)
 
     G, B = _PM.calc_branch_y(branch)
-    if isa(G, Float64) G = [G] end
-    if isa(B, Float64) B = [B] end
 
-    constraint_mc_ohms_yt_from(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], G, B, branch["g_fr"], branch["b_fr"])
+    constraint_mc_ohms_yt_from(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], Array(G), Array(B), branch["g_fr"], branch["b_fr"])
 end
 
 
@@ -116,10 +114,8 @@ function constraint_mc_ohms_yt_to(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm
     t_idx = (i, t_bus, f_bus)
 
     G, B = _PM.calc_branch_y(branch)
-    if isa(G, Float64) G = [G] end
-    if isa(B, Float64) B = [B] end
 
-    constraint_mc_ohms_yt_to(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], G, B, branch["g_to"], branch["b_to"])
+    constraint_mc_ohms_yt_to(pm, nw, f_bus, t_bus, f_idx, t_idx, branch["f_connections"], branch["t_connections"], Array(G), Array(B), branch["g_to"], branch["b_to"])
 end
 
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -460,7 +460,7 @@ q_fr == -b[c,c] *vm_fr[c]^2 -
             )
 ```
 """
-function constraint_mc_ohms_yt_from(pm::_PM.AbstractACPModel, nw::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, t_connections::Vector{Int}, G::Matrix{<:Real}, B::Matrix{<:Real}, G_fr::Matrix{<:Real}, B_fr::Matrix{<:Real})
+function constraint_mc_ohms_yt_from(pm::_PM.AbstractACPModel, nw::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, t_connections::Vector{Int}, G::Array{<:Real}, B::Array{<:Real}, G_fr::Array{<:Real}, B_fr::Array{<:Real})
     p_fr  = var(pm, nw,  :p, f_idx)
     q_fr  = var(pm, nw,  :q, f_idx)
     vm_fr = var(pm, nw, :vm, f_bus)
@@ -498,7 +498,7 @@ p[t_idx] ==  (g+g_to)*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bu
 q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_mc_ohms_yt_to(pm::_PM.AbstractACPModel, nw::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, t_connections::Vector{Int}, G::Matrix{<:Real}, B::Matrix{<:Real}, G_to::Matrix{<:Real}, B_to::Matrix{<:Real})
+function constraint_mc_ohms_yt_to(pm::_PM.AbstractACPModel, nw::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, t_connections::Vector{Int}, G::Array{<:Real}, B::Array{<:Real}, G_to::Array{<:Real}, B_to::Array{<:Real})
     constraint_mc_ohms_yt_from(pm, nw, t_bus, f_bus, t_idx, f_idx, t_connections, f_connections, G, B, G_to, B_to)
 end
 

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -546,12 +546,26 @@ s_fr = (vr_fr+im*vi_fr).*(G-im*B)*([vr_fr-vr_to]-im*[vi_fr-vi_to])
 s_fr = (vr_fr+im*vi_fr).*([G*vr_fr-G*vr_to-B*vi_fr+B*vi_to]-im*[G*vi_fr-G*vi_to+B*vr_fr-B*vr_to])
 """
 function constraint_mc_ohms_yt_from(pm::_PM.AbstractACRModel, nw::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, t_connections::Vector{Int}, G::Matrix{<:Real}, B::Matrix{<:Real}, G_fr::Matrix{<:Real}, B_fr::Matrix{<:Real})
-    p_fr  = [var(pm, nw, :p, f_idx)[t] for t in f_connections]
-    q_fr  = [var(pm, nw, :q, f_idx)[t] for t in f_connections]
-    vr_fr = [var(pm, nw, :vr, f_bus)[t] for t in f_connections]
-    vr_to = [var(pm, nw, :vr, t_bus)[t] for t in t_connections]
-    vi_fr = [var(pm, nw, :vi, f_bus)[t] for t in f_connections]
-    vi_to = [var(pm, nw, :vi, t_bus)[t] for t in t_connections]
+    display("connections are")
+    display(f_connections)
+    display(t_connections)
+    f_conn = intersect(Set(f_connections), Set(t_connections))
+    t_conn = intersect(Set(f_connections), Set(t_connections))
+    p_fr  = [var(pm, nw, :p, f_idx)[t] for t in f_conn]
+    q_fr  = [var(pm, nw, :q, f_idx)[t] for t in f_conn]
+    vr_fr = [var(pm, nw, :vr, f_bus)[t] for t in f_conn]
+    vr_to = [var(pm, nw, :vr, t_bus)[t] for t in t_conn]
+    vi_fr = [var(pm, nw, :vi, f_bus)[t] for t in f_conn]
+    vi_to = [var(pm, nw, :vi, t_bus)[t] for t in t_conn]
+
+    display("p_fr is $p_fr")
+    display("q_fr is $q_fr")
+    display("vr_fr is $vr_fr")
+    display("vr_to is $vr_to")
+    display("vi_fr is $vi_fr")
+    display("vi_to is $vi_to")
+    display("G is $G")
+    display("B is $B")
 
     JuMP.@constraint(pm.model,
             p_fr .==  vr_fr.*(G*vr_fr-G*vr_to-B*vi_fr+B*vi_to)

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -142,7 +142,7 @@ end
 
 
 "Defines branch flow model power flow equations"
-function constraint_mc_power_losses(pm::AbstractUBFModels, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, r::Matrix{<:Real}, x::Matrix{<:Real}, g_sh_fr::Matrix{<:Real}, g_sh_to::Matrix{<:Real}, b_sh_fr::Matrix{<:Real}, b_sh_to::Matrix{<:Real})
+function constraint_mc_power_losses(pm::AbstractUBFModels, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, r::Array{<:Real}, x::Array{<:Real}, g_sh_fr::Array{<:Real}, g_sh_to::Array{<:Real}, b_sh_fr::Array{<:Real}, b_sh_to::Array{<:Real})
     fr_bus_terminals = ref(pm, nw, :bus, f_bus, "terminals")
     to_bus_terminals = ref(pm, nw, :bus, t_bus, "terminals")
 
@@ -188,7 +188,7 @@ end
 
 
 "Defines voltage drop over a branch, linking from and to side voltage"
-function constraint_mc_model_voltage_magnitude_difference(pm::AbstractUBFModels, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, r::Matrix{<:Real}, x::Matrix{<:Real}, g_sh_fr::Matrix{<:Real}, b_sh_fr::Matrix{<:Real})
+function constraint_mc_model_voltage_magnitude_difference(pm::AbstractUBFModels, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx::Tuple{Int,Int,Int}, t_idx::Tuple{Int,Int,Int}, r::Array{<:Real}, x::Array{<:Real}, g_sh_fr::Array{<:Real}, b_sh_fr::Array{<:Real})
     fr_bus_terminals = ref(pm, nw, :bus, f_bus, "terminals")
     to_bus_terminals = ref(pm, nw, :bus, t_bus, "terminals")
 

--- a/src/form/bf_mx_lin.jl
+++ b/src/form/bf_mx_lin.jl
@@ -61,13 +61,9 @@ function constraint_mc_model_voltage_magnitude_difference(pm::LPUBFDiagModel, n:
     p_fr = var(pm, n, :p)[f_idx]
     q_fr = var(pm, n, :q)[f_idx]
 
-    if size(f_connections)[1] == 1 
-        p_s_fr = [p_fr[fc]- diagm(g_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]
-        q_s_fr = [q_fr[fc]+ diagm(b_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]
-    else
-        p_s_fr = [p_fr[fc]- diag(g_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]
-        q_s_fr = [q_fr[fc]+ diag(b_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]    
-    end
+    dg = size(f_connections)[1] == 1 ? :diagm : :diag 
+    p_s_fr = [p_fr[fc]- eval.(dg)(g_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]
+    q_s_fr = [q_fr[fc]+ eval.(dg)(b_sh_fr)[idx].*w_fr[fc] for (idx,fc) in enumerate(f_connections)]
     
     alpha = exp(-im*2*pi/3)
     Gamma = [1 alpha^2 alpha; alpha 1 alpha^2; alpha^2 alpha 1][f_connections,t_connections]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,4 +67,7 @@ include("common.jl")
     include("mld.jl")
 
     include("data_model.jl")
+
+    include("single_connections.jl")
+    
 end

--- a/test/single_connections.jl
+++ b/test/single_connections.jl
@@ -28,44 +28,41 @@
         sol = solve_mc_pf(case3_unbalanced, ACPPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, ACPPowerModel, ipopt_solver)
         for b in ["1", "2"]
-            @test isapprox.(sol["solution"]["bus"][b]["vm"], sol_reduced["solution"]["bus"][b]["vm"])
-            @test isapprox.(sol["solution"]["bus"][b]["va"], sol_reduced["solution"]["bus"][b]["va"])
+            @test all(isapprox.(sol["solution"]["bus"][b]["vm"], sol_reduced["solution"]["bus"][b]["vm"]))
+            @test all(isapprox.(sol["solution"]["bus"][b]["va"], sol_reduced["solution"]["bus"][b]["va"]))
         end
-        @test isapprox.(sol["solution"]["bus"]["3"]["vm"][2], sol_reduced["solution"]["bus"]["3"]["vm"])
-        @test isapprox.(sol["solution"]["bus"]["3"]["va"][2], sol_reduced["solution"]["bus"]["3"]["va"])
+        @test isapprox(sol["solution"]["bus"]["3"]["vm"][2], sol_reduced["solution"]["bus"]["3"]["vm"][1])
+        @test isapprox(sol["solution"]["bus"]["3"]["va"][2], sol_reduced["solution"]["bus"]["3"]["va"][1])
     end
 
     @testset "sc acr pf" begin
         sol = solve_mc_pf(case3_unbalanced, ACRPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, ACRPowerModel, ipopt_solver)
         for b in ["1", "2"]
-            @test isapprox.(sol["solution"]["bus"][b]["vr"], sol_reduced["solution"]["bus"][b]["vr"])
-            @test isapprox.(sol["solution"]["bus"][b]["vi"], sol_reduced["solution"]["bus"][b]["vi"])
+            @test all(isapprox.(sol["solution"]["bus"][b]["vr"], sol_reduced["solution"]["bus"][b]["vr"]))
+            @test all(isapprox.(sol["solution"]["bus"][b]["vi"], sol_reduced["solution"]["bus"][b]["vi"]))
         end
-        @test isapprox.(sol["solution"]["bus"]["3"]["vr"][2], sol_reduced["solution"]["bus"]["3"]["vr"])
-        @test isapprox.(sol["solution"]["bus"]["3"]["vi"][2], sol_reduced["solution"]["bus"]["3"]["vi"])
+        @test isapprox(sol["solution"]["bus"]["3"]["vr"][2], sol_reduced["solution"]["bus"]["3"]["vr"][1])
+        @test isapprox(sol["solution"]["bus"]["3"]["vi"][2], sol_reduced["solution"]["bus"]["3"]["vi"][1])
     end
 
     @testset "sc ivr pf" begin
         sol = solve_mc_pf(case3_unbalanced, IVRPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, IVRPowerModel, ipopt_solver)
+        for b in ["1", "2"]
+            @test all(isapprox.(sol["solution"]["bus"][b]["vr"], sol_reduced["solution"]["bus"][b]["vr"]))
+            @test all(isapprox.(sol["solution"]["bus"][b]["vi"], sol_reduced["solution"]["bus"][b]["vi"]))
+        end
+        @test isapprox(sol["solution"]["bus"]["3"]["vr"][2], sol_reduced["solution"]["bus"]["3"]["vr"][1])
+        @test isapprox(sol["solution"]["bus"]["3"]["vi"][2], sol_reduced["solution"]["bus"]["3"]["vi"][1])
     end
 
     @testset "sc LinDist3Flow pf" begin
         sol = solve_mc_pf(case3_unbalanced, LPUBFDiagPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, LPUBFDiagPowerModel, ipopt_solver)
+        for b in ["1", "2"]
+            @test all(isapprox.(sol["solution"]["bus"][b]["w"], sol_reduced["solution"]["bus"][b]["w"]))
+        end
+        @test isapprox(sol["solution"]["bus"]["3"]["w"][2], sol_reduced["solution"]["bus"]["3"]["w"][1])
     end
-    # @testset "sc SOCNLPUBF pf" begin
-    #     sol = solve_mc_pf(case3_unbalanced, SOCNLPUBFPowerModel, ipopt_solver)
-    #     sol_reduced = solve_mc_pf(case3_reduced, SOCNLPUBFPowerModel, ipopt_solver)
-    # end
-    # @testset "sc SDPUBF pf" begin
-    #     sol = solve_mc_pf(case3_unbalanced, SDPUBFPowerModel, scs_solver)
-    #     sol_reduced = solve_mc_pf(case3_reduced, SDPUBFPowerModel, scs_solver)
-    # end
-    # @testset "sc SOCConicUBF pf" begin
-    #     sol = solve_mc_pf(case3_unbalanced, SOCConicUBFPowerModel, scs_solver)
-    #     sol_reduced = solve_mc_pf(case3_reduced, SOCConicUBFPowerModel, scs_solver)
-    # end
-
 end

--- a/test/single_connections.jl
+++ b/test/single_connections.jl
@@ -1,0 +1,62 @@
+@info "running single connections (sc) tests"
+
+@testset "test sc" begin
+
+    case3_unbalanced = parse_file("../test/data/opendss/case3_unbalanced.dss", data_model = MATHEMATICAL)
+   
+    # remove line charging
+    for (b, branch) in case3_unbalanced["branch"] branch["b_to"] = fill(0.0, (3,3)) end
+    for (b, branch) in case3_unbalanced["branch"] branch["b_fr"] = fill(0.0, (3,3)) end
+    for l in ["2", "3"] delete!(case3_unbalanced["load"], l) end #remaining load "1" is connected to phase 2
+    case3_unbalanced["branch"]["1"]["br_x"] = Array(Diagonal(case3_unbalanced["branch"]["1"]["br_x"]))
+    case3_unbalanced["branch"]["1"]["br_r"] = Array(Diagonal(case3_unbalanced["branch"]["1"]["br_r"]))
+
+    case3_reduced = deepcopy(case3_unbalanced)
+    case3_reduced["bus"]["3"]["terminals"] = [2]
+    case3_reduced["bus"]["3"]["grounded"] = Bool[0]
+    case3_reduced["bus"]["3"]["vmin"] = [0.0]
+    case3_reduced["bus"]["3"]["vmax"] = [Inf]
+    case3_reduced["branch"]["1"]["t_connections"], case3_reduced["branch"]["1"]["f_connections"] = [2], [2]
+    case3_reduced["branch"]["1"]["br_r"] = case3_reduced["branch"]["1"]["br_r"][2,2]
+    case3_reduced["branch"]["1"]["br_x"] = case3_reduced["branch"]["1"]["br_x"][2,2]
+    case3_reduced["branch"]["1"]["g_to"] = [case3_reduced["branch"]["1"]["g_to"][1]]
+    case3_reduced["branch"]["1"]["g_fr"] = [case3_reduced["branch"]["1"]["g_fr"][1]]
+    case3_reduced["branch"]["1"]["b_to"] = [case3_reduced["branch"]["1"]["b_to"][1]]
+    case3_reduced["branch"]["1"]["b_fr"] = [case3_reduced["branch"]["1"]["b_fr"][1]]
+
+    @testset "sc acp pf" begin
+        sol = solve_mc_pf(case3_unbalanced, ACPPowerModel, ipopt_solver)
+        sol_reduced = solve_mc_pf(case3_reduced, ACPPowerModel, ipopt_solver)
+        for b in ["1", "2"]
+            @test isapprox.(sol["solution"]["bus"][b]["vm"], sol_reduced["solution"]["bus"][b]["vm"])
+            @test isapprox.(sol["solution"]["bus"][b]["va"], sol_reduced["solution"]["bus"][b]["va"])
+        end
+        @test isapprox.(sol["solution"]["bus"]["3"]["vm"][2], sol_reduced["solution"]["bus"]["3"]["vm"])
+        @test isapprox.(sol["solution"]["bus"]["3"]["va"][2], sol_reduced["solution"]["bus"]["3"]["va"])
+    end
+    @testset "sc acr pf" begin
+        sol = solve_mc_pf(case3_unbalanced, ACRPowerModel, ipopt_solver)
+        sol_reduced = solve_mc_pf(case3_reduced, ACRPowerModel, ipopt_solver)
+    end
+    @testset "sc ivr pf" begin
+        sol = solve_mc_pf(case3_unbalanced, IVRPowerModel, ipopt_solver)
+        sol_reduced = solve_mc_pf(case3_reduced, IVRPowerModel, ipopt_solver)
+    end
+    @testset "sc LinDist3Flow pf" begin
+        sol = solve_mc_pf(case3_unbalanced, LPUBFDiagPowerModel, ipopt_solver)
+        sol_reduced = solve_mc_pf(case3_reduced, LPUBFDiagPowerModel, ipopt_solver)
+    end
+    # @testset "sc SOCNLPUBF pf" begin
+    #     sol = solve_mc_pf(case3_unbalanced, SOCNLPUBFPowerModel, ipopt_solver)
+    #     sol_reduced = solve_mc_pf(case3_reduced, SOCNLPUBFPowerModel, ipopt_solver)
+    # end
+    # @testset "sc SDPUBF pf" begin
+    #     sol = solve_mc_pf(case3_unbalanced, SDPUBFPowerModel, scs_solver)
+    #     sol_reduced = solve_mc_pf(case3_reduced, SDPUBFPowerModel, scs_solver)
+    # end
+    # @testset "sc SOCConicUBF pf" begin
+    #     sol = solve_mc_pf(case3_unbalanced, SOCConicUBFPowerModel, scs_solver)
+    #     sol_reduced = solve_mc_pf(case3_reduced, SOCConicUBFPowerModel, scs_solver)
+    # end
+
+end

--- a/test/single_connections.jl
+++ b/test/single_connections.jl
@@ -17,8 +17,8 @@
     case3_reduced["bus"]["3"]["vmin"] = [0.0]
     case3_reduced["bus"]["3"]["vmax"] = [Inf]
     case3_reduced["branch"]["1"]["t_connections"], case3_reduced["branch"]["1"]["f_connections"] = [2], [2]
-    case3_reduced["branch"]["1"]["br_r"] = case3_reduced["branch"]["1"]["br_r"][2,2]
-    case3_reduced["branch"]["1"]["br_x"] = case3_reduced["branch"]["1"]["br_x"][2,2]
+    case3_reduced["branch"]["1"]["br_r"] = [case3_reduced["branch"]["1"]["br_r"][2,2]]
+    case3_reduced["branch"]["1"]["br_x"] = [case3_reduced["branch"]["1"]["br_x"][2,2]]
     case3_reduced["branch"]["1"]["g_to"] = [case3_reduced["branch"]["1"]["g_to"][1]]
     case3_reduced["branch"]["1"]["g_fr"] = [case3_reduced["branch"]["1"]["g_fr"][1]]
     case3_reduced["branch"]["1"]["b_to"] = [case3_reduced["branch"]["1"]["b_to"][1]]
@@ -34,14 +34,23 @@
         @test isapprox.(sol["solution"]["bus"]["3"]["vm"][2], sol_reduced["solution"]["bus"]["3"]["vm"])
         @test isapprox.(sol["solution"]["bus"]["3"]["va"][2], sol_reduced["solution"]["bus"]["3"]["va"])
     end
+
     @testset "sc acr pf" begin
         sol = solve_mc_pf(case3_unbalanced, ACRPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, ACRPowerModel, ipopt_solver)
+        for b in ["1", "2"]
+            @test isapprox.(sol["solution"]["bus"][b]["vr"], sol_reduced["solution"]["bus"][b]["vr"])
+            @test isapprox.(sol["solution"]["bus"][b]["vi"], sol_reduced["solution"]["bus"][b]["vi"])
+        end
+        @test isapprox.(sol["solution"]["bus"]["3"]["vr"][2], sol_reduced["solution"]["bus"]["3"]["vr"])
+        @test isapprox.(sol["solution"]["bus"]["3"]["vi"][2], sol_reduced["solution"]["bus"]["3"]["vi"])
     end
+
     @testset "sc ivr pf" begin
         sol = solve_mc_pf(case3_unbalanced, IVRPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, IVRPowerModel, ipopt_solver)
     end
+
     @testset "sc LinDist3Flow pf" begin
         sol = solve_mc_pf(case3_unbalanced, LPUBFDiagPowerModel, ipopt_solver)
         sol_reduced = solve_mc_pf(case3_reduced, LPUBFDiagPowerModel, ipopt_solver)


### PR DESCRIPTION
The scope of this pull request is to enable single-phase buses and branches, see #319  .
Currently, I did it for ivr, acr, acp and lindist3flow.  I think acp and ld3f look ok, whereas the ivr and acr workarounds are not very elegant (if loop that checks the dimension of impedance array + almost duplicated code).
This is because if impedance arrays are 1x1 and you try to multiply, e.g., a 1x1 `G` and a 1x1 `vr_to` like [here](https://github.com/lanl-ansi/PowerModelsDistribution.jl/blob/master/src/form/acr.jl#L557), julia will throw an error saying that the dimensions are not right for matrix multiplication.
On the other hand, if you pass the impedance values as scalars:
1) it makes the construction of the data dictionary less consistent, imho, 
2) to allow for 1x1 impedance elements I "downgraded" the method definitions in the interested constraints from `G::Matrix` to `G::Array`. If you would allow them to even be scalars, you would need a `Any` or a `Union`, but this also didn't seem very nice.
I suppose one workaround could be to edit something upstream, e.g., in `calc_branch_y` or  G, B in `constraint_mc_ohms_yt_to\from` in constraint_template.jl, but I wanted to check first what you think the best approach is.