### PR TITLE
ADD: Load models for LinDist3Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## staged
 
-- none
+- Added delta/voltage-dependent loads to LinDist3Flow formulation
 
 ## v0.11.4
 

--- a/src/core/variable_mx.jl
+++ b/src/core/variable_mx.jl
@@ -23,8 +23,8 @@ function _make_matrix_variable_element(model::JuMP.Model, indices::Array{T,1}, n
     upper_bound::Union{Missing, Dict{T,<:Matrix{<:Real}}}=missing,
     lower_bound::Union{Missing, Dict{T,<:Matrix{<:Real}}}=missing,
     varname::String="") where T
-    nm_has_lb = !(ismissing(lower_bound) || all([lower_bound[index][n,m]==-Inf for index in indices]))
-    nm_has_ub = !(ismissing(upper_bound) || all([upper_bound[index][n,m]== Inf for index in indices]))
+    nm_has_lb = !(ismissing(lower_bound) || all([lower_bound[index][n,m]==-Inf || isnan(lower_bound[index][n,m]) for index in indices]))
+    nm_has_ub = !(ismissing(upper_bound) || all([upper_bound[index][n,m]== Inf || isnan(upper_bound[index][n,m]) for index in indices]))
 
     if !nm_has_ub && !nm_has_lb
         mat_nm = JuMP.@variable(model, [index in indices],

--- a/src/form/bf_mx_lin.jl
+++ b/src/form/bf_mx_lin.jl
@@ -173,7 +173,21 @@ function constraint_mc_storage_losses(pm::AbstractUBFModels, i::Int; nw::Int=nw_
     )
 end
 
-## KIG modifications
+@doc raw"""
+    constraint_mc_load_power(pm::LPUBFDiagModel, load_id::Int; nw::Int=nw_id_default, report::Bool=true)
+
+Delta/voltage-dependent load models for LPUBFDiagModel. Delta loads use the auxilary power variable (X). The constant current load model is derived by linearizing around the flat-start voltage solution. 
+
+```math
+\begin{align}
+&\text{Constant power:} \Rightarrow P_i^d = P_i^{d0},~Q_i^d = Q_i^{d0} ~\forall i \in L \\
+&\text{Constant impedance (Wye):} \Rightarrow P_i^d = a_i \cdot w_i,~Q_i^d = b_i \cdot w_i ~\forall i \in L \\
+&\text{Constant impedance (Delta):} \Rightarrow P_i^d = 3\cdot a_i \cdot w_i,~Q_i^d = 3\cdot b_i \cdot w_i ~\forall i \in L \\
+&\text{Constant current (Wye):} \Rightarrow P_i^d = \frac{a_i}{2}\cdot \left( 1+w_i \right),~Q_i^d = \frac{b_i}{2}\cdot \left( 1+w_i \right) \forall i \in L \\
+&\text{Constant current (Delta):} \Rightarrow P_i^d = \frac{\sqrt{3} \cdot a_i}{2}\cdot \left( 1+w_i \right),~Q_i^d = \frac{\sqrt{3} \cdot b_i}{2}\cdot \left( 1+w_i \right) \forall i \in L 
+\end{align}
+```
+"""
 function constraint_mc_load_power(pm::LPUBFDiagModel, load_id::Int; nw::Int=nw_id_default, report::Bool=true)
     # shared variables and parameters
     load = ref(pm, nw, :load, load_id)
@@ -270,3 +284,4 @@ function constraint_mc_load_power(pm::LPUBFDiagModel, load_id::Int; nw::Int=nw_i
         end
     end
 end
+

--- a/src/form/bf_mx_lin.jl
+++ b/src/form/bf_mx_lin.jl
@@ -172,3 +172,101 @@ function constraint_mc_storage_losses(pm::AbstractUBFModels, i::Int; nw::Int=nw_
         qsc + q_loss
     )
 end
+
+## KIG modifications
+function constraint_mc_load_power(pm::LPUBFDiagModel, load_id::Int; nw::Int=nw_id_default, report::Bool=true)
+    # shared variables and parameters
+    load = ref(pm, nw, :load, load_id)
+    connections = load["connections"]
+    pd0 = load["pd"]
+    qd0 = load["qd"]
+    bus_id = load["load_bus"]
+    bus = ref(pm, nw, :bus, bus_id)
+    terminals = bus["terminals"]
+
+    # calculate load params
+    a, alpha, b, beta = _load_expmodel_params(load, bus)
+    vmin, vmax = _calc_load_vbounds(load, bus)
+    wmin = vmin.^2
+    wmax = vmax.^2
+    pmin, pmax, qmin, qmax = _calc_load_pq_bounds(load, bus)
+    
+    # take care of connections
+    if load["configuration"]==WYE
+        if load["model"]==POWER
+            var(pm, nw, :pd)[load_id] = JuMP.Containers.DenseAxisArray(pd0, connections)
+            var(pm, nw, :qd)[load_id] = JuMP.Containers.DenseAxisArray(qd0, connections)
+        elseif load["model"]==IMPEDANCE
+            w = var(pm, nw, :w)[bus_id][[c for c in connections]]
+            var(pm, nw, :pd)[load_id] = a.*w
+            var(pm, nw, :qd)[load_id] = b.*w
+        # in this case, :pd has a JuMP variable
+        else
+            w = var(pm, nw, :w)[bus_id][[c for c in connections]] 
+            pd = var(pm, nw, :pd)[load_id]
+            qd = var(pm, nw, :qd)[load_id]
+            for (idx,c) in enumerate(connections)
+                JuMP.@constraint(pm.model, pd[c]==1/2*a[idx]*(w[c]+1))
+                JuMP.@constraint(pm.model, qd[c]==1/2*b[idx]*(w[c]+1))
+            end
+        end
+        # :pd_bus is identical to :pd now
+        var(pm, nw, :pd_bus)[load_id] = var(pm, nw, :pd)[load_id]
+        var(pm, nw, :qd_bus)[load_id] = var(pm, nw, :qd)[load_id]
+
+        ## reporting
+        if report
+            sol(pm, nw, :load, load_id)[:pd] = var(pm, nw, :pd)[load_id]
+            sol(pm, nw, :load, load_id)[:qd] = var(pm, nw, :qd)[load_id]
+            sol(pm, nw, :load, load_id)[:pd_bus] = var(pm, nw, :pd_bus)[load_id]
+            sol(pm, nw, :load, load_id)[:qd_bus] = var(pm, nw, :qd_bus)[load_id]
+        end
+    elseif load["configuration"]==DELTA
+        Xdr = var(pm, nw, :Xdr, load_id)
+        Xdi = var(pm, nw, :Xdi, load_id)
+        Td = [1 -1 0; 0 1 -1; -1 0 1]  # TODO
+        # define pd/qd and pd_bus/qd_bus as affine transformations of X
+        pd_bus = LinearAlgebra.diag(Xdr*Td)
+        qd_bus = LinearAlgebra.diag(Xdi*Td)
+        pd = LinearAlgebra.diag(Td*Xdr)
+        qd = LinearAlgebra.diag(Td*Xdi)
+        # Equate missing edge parameters to zero
+        for (idx, c) in enumerate(connections)
+            if abs(pd0[idx]+im*qd0[idx]) == 0.0
+                JuMP.@constraint(pm.model, Xdr[:,idx] .== 0)
+                JuMP.@constraint(pm.model, Xdi[:,idx] .== 0)
+            end
+        end
+
+        var(pm, nw, :pd_bus)[load_id] = pd_bus
+        var(pm, nw, :qd_bus)[load_id] = qd_bus
+        var(pm, nw, :pd)[load_id] = pd
+        var(pm, nw, :qd)[load_id] = qd
+        if load["model"]==POWER
+            for (idx, c) in enumerate(connections)
+                JuMP.@constraint(pm.model, pd[idx]==pd0[idx])
+                JuMP.@constraint(pm.model, qd[idx]==qd0[idx])
+            end
+        elseif load["model"]==IMPEDANCE
+            w = var(pm, nw, :w)[bus_id][[c for c in connections]]     
+            for (idx,c) in enumerate(connections)
+                JuMP.@constraint(pm.model, pd[idx]==3*a[idx]*w[idx])
+                JuMP.@constraint(pm.model, qd[idx]==3*b[idx]*w[idx])
+            end
+        else
+            w = var(pm, nw, :w)[bus_id][[c for c in connections]] 
+            for (idx,c) in enumerate(connections)
+                JuMP.@constraint(pm.model, pd[idx]==sqrt(3)/2*a[idx]*(w[idx]+1))
+                JuMP.@constraint(pm.model, qd[idx]==sqrt(3)/2*b[idx]*(w[idx]+1))
+            end
+        end
+
+        ## reporting; for delta these are not available as saved variables!
+        if report
+            sol(pm, nw, :load, load_id)[:pd] = pd
+            sol(pm, nw, :load, load_id)[:qd] = qd
+            sol(pm, nw, :load, load_id)[:pd_bus] = pd_bus
+            sol(pm, nw, :load, load_id)[:qd_bus] = qd_bus
+        end
+    end
+end

--- a/test/data/opendss/case3_unbalanced_delta_loads.dss
+++ b/test/data/opendss/case3_unbalanced_delta_loads.dss
@@ -38,3 +38,4 @@ set defaultbasefreq=50
 Calcvoltagebases
 
 Solve
+

--- a/test/data/opendss/case3_unbalanced_delta_loads.dss
+++ b/test/data/opendss/case3_unbalanced_delta_loads.dss
@@ -1,0 +1,40 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6 basemva=0.5
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3  Primary.1.2.3  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3  loadbus.1.2.3  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.2   conn=Delta kv=0.4   kW=9   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.3   conn=Delta kv=0.4  kW=6   kvar=3  model=2
+New Load.L3 phases=1  loadbus.3.1   conn=Delta kv=0.4  kW=6   kvar=3  model=5
+New Load.L4 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=9   kvar=3  model=1
+New Load.L5 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=2
+New Load.L6 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=5
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/opf_bf.jl
+++ b/test/opf_bf.jl
@@ -49,6 +49,15 @@
             @test sol["termination_status"] == LOCALLY_SOLVED
             @test norm(sol["solution"]["bus"]["loadbus"]["w"]-[0.92234, 0.95778], Inf) <= 1E-4
         end
+        @testset "3-bus unbalanced lpubfdiag opf_bf with delta loads" begin
+            pmd = parse_file("../test/data/opendss/case3_unbalanced_delta_loads.dss")
+            apply_voltage_bounds!(pmd; vm_lb=0.9, vm_ub=1.1);
+            sol = solve_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
+            @test sol["termination_status"] == LOCALLY_SOLVED
+            baseMVA = sol["solution"]["settings"]["sbase"] / sol["solution"]["settings"]["power_scale_factor"]
+            @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["pg"] * baseMVA), 0.04026874; atol=2e-3)
+            @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["qg"] * baseMVA), 0.0171721; atol=2e-3)
+        end
     end
 
     @testset "test linearised distflow opf_bf in diagonal matrix form" begin

--- a/test/opf_bf.jl
+++ b/test/opf_bf.jl
@@ -51,12 +51,14 @@
         end
         @testset "3-bus unbalanced lpubfdiag opf_bf with delta loads" begin
             pmd = parse_file("../test/data/opendss/case3_unbalanced_delta_loads.dss")
-            apply_voltage_bounds!(pmd; vm_lb=0.9, vm_ub=1.1);
+            apply_voltage_bounds!(pmd; vm_lb=0.94105, vm_ub=0.9959);
             sol = solve_mc_opf(pmd, LPUBFDiagPowerModel, ipopt_solver; make_si=false)
             @test sol["termination_status"] == LOCALLY_SOLVED
             baseMVA = sol["solution"]["settings"]["sbase"] / sol["solution"]["settings"]["power_scale_factor"]
             @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["pg"] * baseMVA), 0.04026874; atol=2e-3)
             @test isapprox(sum(sol["solution"]["voltage_source"]["source"]["qg"] * baseMVA), 0.0171721; atol=2e-3)
+            @test norm(sqrt.(sol["solution"]["bus"]["loadbus"]["w"])-[0.94105, 0.95942, 0.95876], Inf) <= 5E-2
+            @test norm(sqrt.(sol["solution"]["bus"]["primary"]["w"])-[0.97052, 0.97902, 0.97870], Inf) <= 2E-2
         end
     end
 


### PR DESCRIPTION
This adds the following load models to the LinDist3Flow formulation:

1. Wye-connected, constant current loads
2. Delta connected, constant power/current/impedance loads