### PR TITLE
ADD: initial support for CapControl, RegControl dss parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Added support for raw parsing of RegControl and CapControl objects from dss
 - Added delta/voltage-dependent loads to LinDist3Flow formulation
 
 ## v0.11.4

--- a/src/io/dss/dss_data_structs.jl
+++ b/src/io/dss/dss_data_structs.jl
@@ -346,3 +346,35 @@ function _create_spectrum(name::String=""; kwargs...)
     )
 end
 
+
+"""
+Creates a Dict{String,Any} containing all expected properties for a CapControl
+object. See OpenDSS documentation for valid fields and ways to specify
+different properties.
+"""
+function _create_capcontrol(name::String=""; kwargs...)::Dict{String,Any}
+    Dict{String,Any}(
+        "element" => get(kwargs, :element, ""),
+        "capacitor" => get(kwargs, :capacitor, ""),
+        "type" => get(kwargs, :type, "current"),
+        "ctphase" => get(kwargs, :ctphase, 1),
+        "ctratio" => get(kwargs, :ctratio, 60.0),
+        "deadtime" => get(kwargs, :deadtime, 300.0),
+        "delay" => get(kwargs, :delay, 15.0),
+        "delayoff" => get(kwargs, :delayoff, 15.0),
+        "eventlog" => get(kwargs, :eventlog, true),
+        "offsetting" => get(kwargs, :offsetting, 200.0),
+        "onsetting" => get(kwargs, :onsetting, 300.0),
+        "ptphase" => get(kwargs, :ptphase, 1),
+        "ptratio" => get(kwargs, :ptratio, 60.0),
+        "terminal" => get(kwargs, :terminal, 1),
+        "vbus" => get(kwargs, :vbus, ""),
+        "vmax" => get(kwargs, :vmax, 126.0),
+        "vmin" => get(kwargs, :vmin, 115.0),
+        "voltoverride" => get(kwargs, :voltoverride, false),
+        "pctminkvar" => get(kwargs, :50.0),
+        "enabled" => get(kwargs, :enabled, true),
+        "like" => get(kwargs, :like, ""),
+    )
+end
+

--- a/src/io/dss/dss_data_structs.jl
+++ b/src/io/dss/dss_data_structs.jl
@@ -386,7 +386,7 @@ different properties.
 """
 function _create_regcontrol(name::String=""; kwargs...)::Dict{String,Any}
     Dict{String,Any}(
-        "transformer" => get(kwargs, :tranformer, ""),
+        "transformer" => get(kwargs, :transformer, ""),
         "winding" => get(kwargs, :winding, 1),
         "vreg" => get(kwargs, :vreg, 120.0),
         "band" => get(kwargs, :band, 3.0),

--- a/src/io/dss/dss_data_structs.jl
+++ b/src/io/dss/dss_data_structs.jl
@@ -372,7 +372,7 @@ function _create_capcontrol(name::String=""; kwargs...)::Dict{String,Any}
         "vmax" => get(kwargs, :vmax, 126.0),
         "vmin" => get(kwargs, :vmin, 115.0),
         "voltoverride" => get(kwargs, :voltoverride, false),
-        "pctminkvar" => get(kwargs, :50.0),
+        "pctminkvar" => get(kwargs, :pctminkvar, 50.0),
         "enabled" => get(kwargs, :enabled, true),
         "like" => get(kwargs, :like, ""),
     )

--- a/src/io/dss/dss_data_structs.jl
+++ b/src/io/dss/dss_data_structs.jl
@@ -354,6 +354,7 @@ different properties.
 """
 function _create_capcontrol(name::String=""; kwargs...)::Dict{String,Any}
     Dict{String,Any}(
+        "name" => name,
         "element" => get(kwargs, :element, ""),
         "capacitor" => get(kwargs, :capacitor, ""),
         "type" => get(kwargs, :type, "current"),
@@ -386,6 +387,7 @@ different properties.
 """
 function _create_regcontrol(name::String=""; kwargs...)::Dict{String,Any}
     Dict{String,Any}(
+        "name" => name,
         "transformer" => get(kwargs, :transformer, ""),
         "winding" => get(kwargs, :winding, 1),
         "vreg" => get(kwargs, :vreg, 120.0),

--- a/src/io/dss/dss_data_structs.jl
+++ b/src/io/dss/dss_data_structs.jl
@@ -378,3 +378,46 @@ function _create_capcontrol(name::String=""; kwargs...)::Dict{String,Any}
     )
 end
 
+
+"""
+Creates a Dict{String,Any} containing all expected properties for a RegControl
+object. See OpenDSS documentation for valid fields and ways to specify
+different properties.
+"""
+function _create_regcontrol(name::String=""; kwargs...)::Dict{String,Any}
+    Dict{String,Any}(
+        "transformer" => get(kwargs, :tranformer, ""),
+        "winding" => get(kwargs, :winding, 1),
+        "vreg" => get(kwargs, :vreg, 120.0),
+        "band" => get(kwargs, :band, 3.0),
+        "delay" => get(kwargs, :delay, 15.0),
+        "ptratio" => get(kwargs, :ptratio, 60.0),
+        "ctprim" => get(kwargs, :ctprim, 300.0),
+        "r" => get(kwargs, :r, 0.0),
+        "x" => get(kwargs, :x, 0.0),
+        "ptphase" => get(kwargs, :ptphase, 1),
+        "tapwinding" => get(kwargs, :tapwinding, get(kwargs, :winding, 1)),
+        "bus" => get(kwargs, :bus, ""),
+        "debugtrace" => get(kwargs, :debugtrace, false),
+        "eventlog" => get(kwargs, :eventlog, true),
+        "inversetime" => get(kwargs, :inversetime, false),
+        "maxtapchange" => get(kwargs, :maxtapchange, 16),
+        "revband" => get(kwargs, :revband, 3.0),
+        "revdelay" => get(kwargs, :revdelay, 60.0),
+        "reversible" => get(kwargs, :reversible, false),
+        "revneutral" => get(kwargs, :revneutral, false),
+        "revr" => get(kwargs, :revr, 0.0),
+        "revthreshold" => get(kwargs, :revthreshold, 100.0),
+        "revvreg" => get(kwargs, :revvreg, 120.0),
+        "revx" => get(kwargs, :revx, 0.0),
+        "tapdelay" => get(kwargs, :tapdelay, 2.0),
+        "tapnum" => get(kwargs, :tapnum, 0),
+        "vlimit" => get(kwargs, :vlimit, 0.0),
+        "rev_z" => get(kwargs, :rev_z, 0.0),
+        "ldc_z" => get(kwargs, :ldc_z, 0.0),
+        "cogen" => get(kwargs, :cogen, false),
+        "remoteptratio" => get(kwargs, :remoteptratio, 60.0),
+        "enabled" => get(kwargs, :enabled, true),
+        "like" => get(kwargs, :like, ""),
+    )
+end

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -31,6 +31,7 @@ const _dss_supported_components = String[
     "line", "linecode", "load", "generator", "capacitor", "reactor",
     "transformer", "pvsystem", "storage", "loadshape", "options",
     "xfmrcode", "vsource", "xycurve", "spectrum", "capcontrol",
+    "regcontrol",
 ]
 
 "two number operators for reverse polish notation"

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -30,7 +30,7 @@ const _dss_monitor_objects = String[
 const _dss_supported_components = String[
     "line", "linecode", "load", "generator", "capacitor", "reactor",
     "transformer", "pvsystem", "storage", "loadshape", "options",
-    "xfmrcode", "vsource", "xycurve", "spectrum",
+    "xfmrcode", "vsource", "xycurve", "spectrum", "capcontrol",
 ]
 
 "two number operators for reverse polish notation"

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -101,3 +101,5 @@ new linecode.test_matrix_syntax phases=3 rmatrix=[0.1 0.0 0.0 |0.0 0.1 ,0.0 |0.0
 new xycurve.test_delimiters points=[  1,2  3  ,4]
 
 setbusxy bus=testsource x=0.1 y=0.2
+
+New CapControl.c1_Ctrl Capacitor=c1 element=Line.L2  terminal=1 type=kvar ptratio=1 ctratio=1 ONsetting=150 OFFsetting=-225 VoltOverride=Y Vmin=7110 Vmax=7740 Delay=100 Delayoff=100

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -102,4 +102,5 @@ new xycurve.test_delimiters points=[  1,2  3  ,4]
 
 setbusxy bus=testsource x=0.1 y=0.2
 
+new regcontrol.t1  transformer=t1 winding=2  vreg=122  band=2  ptratio=20 ctprim=700  R=3   X=9
 New CapControl.c1_Ctrl Capacitor=c1 element=Line.L2  terminal=1 type=kvar ptratio=1 ctratio=1 ONsetting=150 OFFsetting=-225 VoltOverride=Y Vmin=7110 Vmax=7740 Delay=100 Delayoff=100

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -200,24 +200,24 @@
     end
 
     @testset "opendss parse verify mvasc3/mvasc1 circuit parse" begin
-        dss = parse_dss("../test/data/opendss/test_simple.dss")
-        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss["vsource"]["source"])...)
+        dss_data = parse_dss("../test/data/opendss/test_simple.dss")
+        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss_data["vsource"]["source"])...)
 
         @test circuit["mvasc1"] == 2100.0
         @test circuit["mvasc3"] == 1900.0
         @test isapprox(circuit["isc3"], 9538.8; atol=1e-1)
         @test isapprox(circuit["isc1"], 10543.0; atol=1e-1)
 
-        dss = parse_dss("../test/data/opendss/test_simple3.dss")
-        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss["vsource"]["source"])...)
+        dss_data = parse_dss("../test/data/opendss/test_simple3.dss")
+        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss_data["vsource"]["source"])...)
 
         @test circuit["mvasc1"] == 2100.0
         @test isapprox(circuit["mvasc3"], 1900.0; atol=1e-1)
         @test circuit["isc3"] == 9538.8
         @test isapprox(circuit["isc1"], 10543.0; atol=1e-1)
 
-        dss = parse_dss("../test/data/opendss/test_simple4.dss")
-        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss["vsource"]["source"])...)
+        dss_data = parse_dss("../test/data/opendss/test_simple4.dss")
+        circuit = PMD._create_vsource("source"; PMD._to_kwargs(dss_data["vsource"]["source"])...)
 
         @test isapprox(circuit["mvasc1"], 2091.5; atol=1e-1)
         @test circuit["mvasc3"] == 2000.0

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -90,7 +90,7 @@
         @test math["name"] == "test2"
 
         @test length(math) == 17
-        @test length(dss) == 21
+        @test length(dss) == 23
 
         for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "transformer", "storage", "switch"], [34, 4, 5, 28, 5, 10, 1, 1])
             @test haskey(math, key)

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -254,6 +254,48 @@
             "like" => "",
         )
     end
+
+    @testset "opendss regcontrol parse" begin
+        raw_obj = dss["regcontrol"]["t1"]
+
+        defaults = PMD._create_regcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
+
+        @test defaults == Dict{String,Any}(
+            "transformer" => "t1",
+            "winding" => 2,
+            "vreg" => 122,
+            "band" => 2.0,
+            "delay" => 15.0,
+            "ptratio" => 20.0,
+            "ctprim" => 700.0,
+            "r" => 3.0,
+            "x" => 9.0,
+            "ptphase" => 1,
+            "tapwinding" => 2,
+            "bus" => "",
+            "debugtrace" => false,
+            "eventlog" => true,
+            "inversetime" => false,
+            "maxtapchange" => 16,
+            "revband" => 3.0,
+            "revdelay" => 60.0,
+            "reversible" => false,
+            "revneutral" => false,
+            "revr" => 0.0,
+            "revthreshold" => 100.0,
+            "revvreg" => 120.0,
+            "revx" => 0.0,
+            "tapdelay" => 2.0,
+            "tapnum" => 0,
+            "vlimit" => 0.0,
+            "rev_z" => 0.0,
+            "ldc_z" => 0.0,
+            "cogen" => false,
+            "remoteptratio" => 60.0,
+            "enabled" => true,
+            "like" => "",
+        )
+    end
 end
 
 @testset "test json parser" begin

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -231,6 +231,7 @@
         defaults = PMD._create_capcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
 
         @test defaults == Dict{String,Any}(
+            "name" => "c1_ctrl",
             "element" => "line.l2",
             "capacitor" => "c1",
             "type" => "kvar",
@@ -261,6 +262,7 @@
         defaults = PMD._create_regcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
 
         @test defaults == Dict{String,Any}(
+            "name" => "t1",
             "transformer" => "t1",
             "winding" => 2,
             "vreg" => 122,

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -224,6 +224,36 @@
         @test circuit["isc3"] == 10041.0
         @test circuit["isc1"] == 10500.0
     end
+
+    @testset "opendss capcontrol parse" begin
+        raw_obj = dss["capcontrol"]["c1_ctrl"]
+
+        defaults = PMD._create_capcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
+
+        @test defaults == Dict{String,Any}(
+            "element" => "line.l2",
+            "capacitor" => "c1",
+            "type" => "kvar",
+            "ctphase" => 1,
+            "ctratio" => 1.0,
+            "deadtime" => get(kwargs, :deadtime, 300.0),
+            "delay" => 100.0,
+            "delayoff" => 100.0,
+            "eventlog" => true,
+            "offsetting" => -225.0,
+            "onsetting" => 150.0,
+            "ptphase" => 1,
+            "ptratio" => 1.0,
+            "terminal" => 1,
+            "vbus" => "",
+            "vmax" => 7740.0,
+            "vmin" => 7110.0,
+            "voltoverride" => true,
+            "pctminkvar" => 50.0,
+            "enabled" => true,
+            "like" => "",
+        )
+    end
 end
 
 @testset "test json parser" begin

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -228,7 +228,7 @@
     @testset "opendss capcontrol parse" begin
         raw_obj = dss["capcontrol"]["c1_ctrl"]
 
-        defaults = PMD._create_capcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
+        defaults = PMD._create_capcontrol(raw_obj["name"]; PMD._to_kwargs(raw_obj)...)
 
         @test defaults == Dict{String,Any}(
             "name" => "c1_ctrl",
@@ -237,7 +237,7 @@
             "type" => "kvar",
             "ctphase" => 1,
             "ctratio" => 1.0,
-            "deadtime" => get(kwargs, :deadtime, 300.0),
+            "deadtime" => 300.0,
             "delay" => 100.0,
             "delayoff" => 100.0,
             "eventlog" => true,
@@ -259,13 +259,13 @@
     @testset "opendss regcontrol parse" begin
         raw_obj = dss["regcontrol"]["t1"]
 
-        defaults = PMD._create_regcontrol(raw_obj["name"], PMD._to_kwargs(raw_obj)...)
+        defaults = PMD._create_regcontrol(raw_obj["name"]; PMD._to_kwargs(raw_obj)...)
 
         @test defaults == Dict{String,Any}(
             "name" => "t1",
             "transformer" => "t1",
             "winding" => 2,
-            "vreg" => 122,
+            "vreg" => 122.0,
             "band" => 2.0,
             "delay" => 15.0,
             "ptratio" => 20.0,


### PR DESCRIPTION
This PR adds initial support for parsing of CapControl and RegControl dss objects in preparation for using them to update transformer and capacitor settings for new problem types in the future.

CC @keatsig 