### PR TITLE
FIX: bug in _dss2eng_loadshape function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## staged
 
 - Fixed bug/typo in `_create_storage` where `kwhstored` was derived from `:stored` instead of `Symbol("%stored")`
+- Fixed bug in function `_dss2eng_loadshape!()` where `qmult` data was overwriting `pmult` data [#386](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/386)
 
 ## v0.14.3
 

--- a/src/io/dss/dss2eng.jl
+++ b/src/io/dss/dss2eng.jl
@@ -47,9 +47,10 @@ function _dss2eng_loadshape!(data_eng::Dict{String,<:Any}, data_dss::Dict{String
             @info "Loadshape '$id' contains mismatched pmult and qmult, splitting into `time_series` ids '$(id)_p' and '$(id)_q'"
             _add_eng_obj!(data_eng, "time_series", "$(id)_p", eng_obj)
 
-            eng_obj["values"] = defaults["qmult"]
+            eng_obj_qmult = deepcopy(eng_obj)
+            eng_obj_qmult["values"] = defaults["qmult"]
 
-            _add_eng_obj!(data_eng, "time_series", "$(id)_q", eng_obj)
+            _add_eng_obj!(data_eng, "time_series", "$(id)_q", eng_obj_qmult)
         else
             _add_eng_obj!(data_eng, "time_series", id, eng_obj)
         end


### PR DESCRIPTION
This PR fixes a bug related to `pmult` values being overwritten by `qmult` values in the `_dss2eng_loadshape!(...)` function when running multinetwork tests with loadshapes. The option to add `pmult` and `qmult` as separate csv files was not working correctly. 

Closes #386.