### PR TITLE
FIX: `parse_file` in `.dss` files with character UTF-8 0x09 (Tabulation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated documentation in `make_multiconductor!` to better indicate its unsupported nature
 - Added automatic detection of multinetwork data to `instantiate_mc_model`
 - Converted `::Float64` types in function signatures to `::Real`
+- Fixed bug in `parse_file` in `.dss` files with character UTF-8 0x09 (Tabulation) [#394](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/394)
 
 ## v0.14.4
 

--- a/src/io/dss/dss_parse.jl
+++ b/src/io/dss/dss_parse.jl
@@ -551,15 +551,15 @@ function _parse_properties(properties::AbstractString)::Vector{String}
         substring_out = split(string_out, "=")
         if length(substring_out) == 2 && substring_out[2] != ""
             end_equality = true
-        elseif !occursin("=", string_out) && (char == ' ' || n == num_chars)
+        elseif !occursin("=", string_out) && (isspace(char) || n == num_chars)
             end_equality = true
-        elseif occursin("=", string_out) && (char == ' ' || n == num_chars) && end_array
+        elseif occursin("=", string_out) && (isspace(char) || n == num_chars) && end_array
             end_equality = true
         else
             end_equality = false
         end
 
-        if char == ' '
+        if isspace(char)
             end_property = true
         else
             end_property = false

--- a/test/data/opendss/case_tabulation.dss
+++ b/test/data/opendss/case_tabulation.dss
@@ -1,0 +1,5 @@
+Clear
+new	circuit.test	bus1=SOURCEBUS	pu=1.0
+New	Line.Line_1	bus1=SOURCEBUS	bus2=BUS_1
+New	Load.Load_1	phases=3	conn=Wye	bus1=BUS_1	kw=0.1	kvar=0.03	model=1
+solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -295,6 +295,13 @@
             "like" => "",
         )
     end
+
+    @testset "tabulation parse" begin
+        eng = parse_file("../test/data/opendss/case_tabulation.dss")
+
+        number_buses = 3
+        @test length(eng["bus"]) == number_buses
+    end
 end
 
 @testset "test different regcontrol configurations" begin


### PR DESCRIPTION
This PR Closes #394. and it is **not** a breaking change.

## Changes
- [Adding a new test case](https://github.com/lanl-ansi/PowerModelsDistribution.jl/commit/fb8e835337e19e9d1efce75b37a53b9d44b1ecfb) that represents the #394 bug.
- [Adding a new test for the new test case](https://github.com/lanl-ansi/PowerModelsDistribution.jl/commit/707cd972ee6b067ce3f1e61c6f810af5c5b59a8f).
- [Changing space validations](https://github.com/lanl-ansi/PowerModelsDistribution.jl/commit/e41649157dd8dcf3c5eb6ab98987ec8dd69e5985) as discussed in https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/394#issuecomment-1216697932.
- [Update CHANGELOG.md](https://github.com/lanl-ansi/PowerModelsDistribution.jl/commit/0906d11f348467d05360d1892a9d8789bb50f846).
