### PR TITLE
ADD: Capacitor control for IVR formulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Add wye-connected CapControl for IVR formulation
 - Added ZIP load model
 - Updated documentation in `make_multiconductor!` to better indicate its unsupported nature
 - Added automatic detection of multinetwork data to `instantiate_mc_model`

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -396,6 +396,26 @@ end
 
 
 """
+    constraint_mc_current_balance_capc(pm::AbstractUnbalancedPowerModel, i::Int; nw::Int=nw_id_default)::Nothing
+
+Template function for KCL constraints in current-voltage variable space with capacitor control variables.
+"""
+function constraint_mc_current_balance_capc(pm::AbstractUnbalancedPowerModel, i::Int; nw::Int=nw_id_default)::Nothing
+    bus = ref(pm, nw, :bus, i)
+    bus_arcs = ref(pm, nw, :bus_arcs_conns_branch, i)
+    bus_arcs_sw = ref(pm, nw, :bus_arcs_conns_switch, i)
+    bus_arcs_trans = ref(pm, nw, :bus_arcs_conns_transformer, i)
+    bus_gens = ref(pm, nw, :bus_conns_gen, i)
+    bus_storage = ref(pm, nw, :bus_conns_storage, i)
+    bus_loads = ref(pm, nw, :bus_conns_load, i)
+    bus_shunts = ref(pm, nw, :bus_conns_shunt, i)
+
+    constraint_mc_current_balance_capc(pm, nw, i, bus["terminals"], bus["grounded"], bus_arcs, bus_arcs_sw, bus_arcs_trans, bus_gens, bus_storage, bus_loads, bus_shunts)
+    nothing
+end
+
+
+"""
     constraint_mc_network_power_balance(pm::AbstractUnbalancedPowerModel, i::Int; nw::Int=nw_id_default)::Nothing
 
 Template function for constraints that ensures that power generation and demand are balanced in OBF problem

--- a/src/form/ivr.jl
+++ b/src/form/ivr.jl
@@ -191,6 +191,16 @@ function variable_mc_bus_voltage(pm::AbstractUnbalancedIVRModel; nw::Int=nw_id_d
 end
 
 
+"""
+    variable_mc_capcontrol(pm::AbstractUnbalancedIVRModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
+
+Capacitor switching variables.
+"""
+function variable_mc_capcontrol(pm::AbstractUnbalancedIVRModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
+    variable_mc_capacitor_switch_state(pm; nw=nw, relax=relax, report=report)
+end
+
+
 "Defines how current distributes over series and shunt impedances of a pi-model branch"
 function constraint_mc_current_from(pm::AbstractUnbalancedIVRModel, nw::Int, f_bus::Int, f_idx::Tuple{Int,Int,Int}, f_connections::Vector{Int}, g_sh_fr::Matrix{<:Real}, b_sh_fr::Matrix{<:Real})
     vr_fr = [var(pm, nw, :vr, f_bus)[c] for c in f_connections]
@@ -304,6 +314,138 @@ function constraint_mc_current_balance(pm::AbstractUnbalancedIVRModel, nw::Int, 
                                     - sum(cid[d][t]         for (d, conns) in bus_loads if t in conns)
                                     - sum( Gt[idx,jdx]*vi[u] +Bt[idx,jdx]*vr[u] for (jdx,u) in ungrounded_terminals) # shunts
                                     )
+    end
+end
+
+
+@doc raw"""
+    constraint_mc_current_balance_capc(pm::AbstractUnbalancedIVRModel, nw::Int, i::Int, terminals::Vector{Int}, grounded::Vector{Bool}, bus_arcs::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_arcs_sw::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_arcs_trans::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_gens::Vector{Tuple{Int,Vector{Int}}}, bus_storage::Vector{Tuple{Int,Vector{Int}}}, bus_loads::Vector{Tuple{Int,Vector{Int}}}, bus_shunts::Vector{Tuple{Int,Vector{Int}}})
+
+Current balance constraints with capacitor control.   
+"""
+function constraint_mc_current_balance_capc(pm::AbstractUnbalancedIVRModel, nw::Int, i::Int, terminals::Vector{Int}, grounded::Vector{Bool}, bus_arcs::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_arcs_sw::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_arcs_trans::Vector{Tuple{Tuple{Int,Int,Int},Vector{Int}}}, bus_gens::Vector{Tuple{Int,Vector{Int}}}, bus_storage::Vector{Tuple{Int,Vector{Int}}}, bus_loads::Vector{Tuple{Int,Vector{Int}}}, bus_shunts::Vector{Tuple{Int,Vector{Int}}})
+    vr = var(pm, nw, :vr, i)
+    vi = var(pm, nw, :vi, i)
+
+    cr    = get(var(pm, nw),    :cr, Dict()); _check_var_keys(cr, bus_arcs, "real current", "branch")
+    ci    = get(var(pm, nw),    :ci, Dict()); _check_var_keys(ci, bus_arcs, "imaginary current", "branch")
+    crd   = get(var(pm, nw),   :crd_bus, Dict()); _check_var_keys(crd, bus_loads, "real current", "load")
+    cid   = get(var(pm, nw),   :cid_bus, Dict()); _check_var_keys(cid, bus_loads, "imaginary current", "load")
+    crg   = get(var(pm, nw),   :crg_bus, Dict()); _check_var_keys(crg, bus_gens, "real current", "generator")
+    cig   = get(var(pm, nw),   :cig_bus, Dict()); _check_var_keys(cig, bus_gens, "imaginary current", "generator")
+    crs   = get(var(pm, nw),   :crs, Dict()); _check_var_keys(crs, bus_storage, "real currentr", "storage")
+    cis   = get(var(pm, nw),   :cis, Dict()); _check_var_keys(cis, bus_storage, "imaginary current", "storage")
+    crsw  = get(var(pm, nw),  :crsw, Dict()); _check_var_keys(crsw, bus_arcs_sw, "real current", "switch")
+    cisw  = get(var(pm, nw),  :cisw, Dict()); _check_var_keys(cisw, bus_arcs_sw, "imaginary current", "switch")
+    crt   = get(var(pm, nw),   :crt, Dict()); _check_var_keys(crt, bus_arcs_trans, "real current", "transformer")
+    cit   = get(var(pm, nw),   :cit, Dict()); _check_var_keys(cit, bus_arcs_trans, "imaginary current", "transformer")
+
+    # add constraints to model capacitor switching
+    if !isempty(bus_shunts) && haskey(ref(pm, nw, :shunt, bus_shunts[1][1]), "controls")
+        constraint_capacitor_on_off(pm, nw, i, bus_shunts)
+    end
+
+    # calculate Gs, Bs
+    ncnds = length(terminals)
+    Gt = fill(0.0, ncnds, ncnds)
+    Bt = convert(Matrix{JuMP.NonlinearExpression}, JuMP.@NLexpression(pm.model, [idx=1:ncnds, jdx=1:ncnds], 0.0))
+    for (val, connections) in bus_shunts
+        shunt = ref(pm,nw,:shunt,val)
+        for (idx,c) in enumerate(connections)
+            cap_state = haskey(shunt,"controls") ? var(pm, nw, :capacitor_state, val)[c] : 1.0
+            for (jdx,d) in enumerate(connections)
+                Gt[findfirst(isequal(c), terminals),findfirst(isequal(d), terminals)] += shunt["gs"][idx,jdx]
+                Bt[findfirst(isequal(c), terminals),findfirst(isequal(d), terminals)] = JuMP.@NLexpression(pm.model, Bt[findfirst(isequal(c), terminals),findfirst(isequal(d), terminals)] + shunt["bs"][idx,jdx]*cap_state)
+            end
+        end
+    end
+
+    ungrounded_terminals = [(idx,t) for (idx,t) in enumerate(terminals) if !grounded[idx]]
+
+    for (idx, t) in ungrounded_terminals
+        @smart_constraint(pm.model,  [cr, crd, crg, crs, crsw, crt, vr, vi, Bt],
+                                      sum(cr[a][t] for (a, conns) in bus_arcs if t in conns)
+                                    + sum(crsw[a_sw][t] for (a_sw, conns) in bus_arcs_sw if t in conns)
+                                    + sum(crt[a_trans][t] for (a_trans, conns) in bus_arcs_trans if t in conns)
+                                    ==
+                                      sum(crg[g][t]         for (g, conns) in bus_gens if t in conns)
+                                    - sum(crs[s][t]         for (s, conns) in bus_storage if t in conns)
+                                    - sum(crd[d][t]         for (d, conns) in bus_loads if t in conns)
+                                    - sum( Gt[idx,jdx]*vr[u] -Bt[idx,jdx]*vi[u] for (jdx,u) in ungrounded_terminals) # shunts
+                                    )
+        @smart_constraint(pm.model, [ci, cid, cig, cis, cisw, cit, vr, vi, Bt],
+                                      sum(ci[a][t] for (a, conns) in bus_arcs if t in conns)
+                                    + sum(cisw[a_sw][t] for (a_sw, conns) in bus_arcs_sw if t in conns)
+                                    + sum(cit[a_trans][t] for (a_trans, conns) in bus_arcs_trans if t in conns)
+                                    ==
+                                      sum(cig[g][t]         for (g, conns) in bus_gens if t in conns)
+                                    - sum(cis[s][t]         for (s, conns) in bus_storage if t in conns)
+                                    - sum(cid[d][t]         for (d, conns) in bus_loads if t in conns)
+                                    - sum( Gt[idx,jdx]*vi[u] +Bt[idx,jdx]*vr[u] for (jdx,u) in ungrounded_terminals) # shunts
+                                    )
+    end
+end
+
+
+@doc raw"""
+    constraint_capacitor_on_off(pm::AbstractUnbalancedIVRModel, i::Int; nw::Int=nw_id_default)
+
+Add constraints to model capacitor switching
+
+```math
+\begin{align}
+&\text{kvar control: } s = (vr_fr+im*vi_fr).*(cr_fr-im*ci_fr),\\
+&\text{kvar control (ON): }  \Im{s}-q_\text{on} ≤ M_q ⋅ z - ϵ ⋅ (1-z), \\
+&\text{kvar control (OFF): } \Im{s}-q_\text{off} ≥ -M_q ⋅ (1-z) - ϵ ⋅ z, \\
+&\text{voltage control (ON): }  v_r^2 + v_i^2 - v_\text{min}^2 ≥ -M_v ⋅ z + ϵ ⋅ (1-z), \\
+&\text{voltage control (OFF): } v_r^2 + v_i^2 - v_\text{max}^2 ≤ M_v ⋅ (1-z) - ϵ ⋅ z.
+\end{align}
+```
+"""
+function constraint_capacitor_on_off(pm::AbstractUnbalancedIVRModel, nw::Int, i::Int, bus_shunts::Vector{Tuple{Int,Vector{Int}}})
+    cap_state = var(pm, nw, :capacitor_state, bus_shunts[1][1])
+    shunt = ref(pm, nw, :shunt, bus_shunts[1][1])
+    ϵ = 1e-5
+    M_q = 1e5
+    M_v = 2
+    elem_type = shunt["controls"]["element"]["type"]
+    if shunt["controls"]["type"] == CAP_REACTIVE_POWER
+        bus_idx = shunt["controls"]["terminal"] == 1 ? (shunt["controls"]["element"]["index"], shunt["controls"]["element"]["f_bus"], shunt["controls"]["element"]["t_bus"]) : (shunt["controls"]["element"]["index"], shunt["controls"]["element"]["t_bus"], shunt["controls"]["element"]["f_bus"])
+        vr_fr = var(pm, nw, :vr, bus_idx[2])
+        vi_fr = var(pm, nw, :vi, bus_idx[2])
+        cr_fr = elem_type == "branch" ? var(pm, nw, :cr)[bus_idx] : elem_type == "switch" ? var(pm, nw, :crsw) : var(pm, nw, :crt, bus_idx)
+        ci_fr = elem_type == "branch" ? var(pm, nw, :ci)[bus_idx] : elem_type == "switch" ? var(pm, nw, :cisw) : var(pm, nw, :cit, bus_idx)
+        q_fr = JuMP.@expression(pm.model, vi_fr.*cr_fr .- vr_fr.*ci_fr)
+        JuMP.@constraint(pm.model, sum(q_fr) - shunt["controls"]["onsetting"] ≤ M_q*cap_state[shunt["connections"][1]] - ϵ*(1-cap_state[shunt["connections"][1]]))
+        JuMP.@constraint(pm.model, sum(q_fr) - shunt["controls"]["offsetting"] ≥ -M_q*(1-cap_state[shunt["connections"][1]]) - ϵ*cap_state[shunt["connections"][1]])
+        JuMP.@constraint(pm.model, cap_state .== cap_state[shunt["connections"][1]])
+        if shunt["controls"]["voltoverride"]
+            for (idx,val) in enumerate(shunt["connections"])
+                vr_cap = var(pm, nw, :vr, i)[val]
+                vi_cap = var(pm, nw, :vi, i)[val]
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["vmin"]^2 ≥ -M_v*cap_state[val] + ϵ*(1-cap_state[val]))
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["vmax"]^2 ≤ M_v*(1-cap_state[val]) - ϵ*cap_state[val])
+            end
+        end
+    else
+        for (idx,val) in enumerate(shunt["connections"])
+            if shunt["controls"]["type"][idx] == CAP_VOLTAGE
+                bus_idx = shunt["controls"]["terminal"][idx] == 1 ? shunt["controls"]["element"]["f_bus"] : shunt["controls"]["element"]["t_bus"]
+                vr_cap = var(pm, nw, :vr, i)[val]
+                vi_cap = var(pm, nw, :vi, i)[val]
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["onsetting"][idx]^2 ≤ M_v*cap_state[val] - ϵ*(1-cap_state[val]))
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["offsetting"][idx]^2 ≥ -M_v*(1-cap_state[val]) - ϵ*cap_state[val])
+            end
+            if shunt["controls"]["voltoverride"][idx]
+                vr_cap = var(pm, nw, :vr, i)[val]
+                vi_cap = var(pm, nw, :vi, i)[val]
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["vmin"][idx]^2 ≥ -M_v*cap_state[val] + ϵ*(1-cap_state[val]))
+                JuMP.@constraint(pm.model, vr_cap^2 + vi_cap^2 - shunt["controls"]["vmax"][idx]^2 ≤ M_v*(1-cap_state[val]) - ϵ*cap_state[val])
+            end
+            if shunt["controls"]["type"][idx] == CAP_DISABLED
+                JuMP.@constraint(pm.model, cap_state[val] == 1 )
+            end
+        end
     end
 end
 

--- a/src/prob/opf_capc.jl
+++ b/src/prob/opf_capc.jl
@@ -67,7 +67,7 @@ function build_mc_opf_capc(pm::AbstractUnbalancedPowerModel)
 end
 
 
-"constructor for branch flow opf"
+"constructor for branch flow opf with capcontrol"
 function build_mc_opf_capc(pm::AbstractUBFModels)
     # Variables
     variable_mc_bus_voltage(pm)
@@ -115,6 +115,63 @@ function build_mc_opf_capc(pm::AbstractUBFModels)
         constraint_mc_switch_state(pm, i)
         constraint_mc_switch_thermal_limit(pm, i)
         constraint_mc_switch_ampacity(pm, i)
+    end
+
+    for i in ids(pm, :transformer)
+        constraint_mc_transformer_power(pm, i)
+    end
+
+    # Objective
+    objective_mc_min_fuel_cost(pm)
+end
+
+
+"constructor for capcontrol OPF in current-voltage variable space"
+function build_mc_opf_capc(pm::AbstractUnbalancedIVRModel)
+    # Variables
+    variable_mc_bus_voltage(pm)
+    variable_mc_branch_current(pm)
+    variable_mc_switch_current(pm)
+    variable_mc_transformer_current(pm)
+    variable_mc_generator_current(pm)
+    variable_mc_load_current(pm)
+
+    variable_mc_capcontrol(pm; relax=true)
+
+    # Constraints
+    for i in ids(pm, :ref_buses)
+        constraint_mc_theta_ref(pm, i)
+    end
+
+    # gens should be constrained before KCL, or Pd/Qd undefined
+    for id in ids(pm, :gen)
+        constraint_mc_generator_power(pm, id)
+    end
+
+    # loads should be constrained before KCL, or Pd/Qd undefined
+    for id in ids(pm, :load)
+        constraint_mc_load_power(pm, id)
+    end
+
+    for i in ids(pm, :bus)
+        constraint_mc_current_balance_capc(pm, i)
+    end
+
+    for i in ids(pm, :branch)
+        constraint_mc_current_from(pm, i)
+        constraint_mc_current_to(pm, i)
+
+        constraint_mc_bus_voltage_drop(pm, i)
+
+        constraint_mc_voltage_angle_difference(pm, i)
+
+        constraint_mc_thermal_limit_from(pm, i)
+        constraint_mc_thermal_limit_to(pm, i)
+    end
+
+    for i in ids(pm, :switch)
+        constraint_mc_switch_state(pm, i)
+        constraint_mc_switch_current_limit(pm, i)
     end
 
     for i in ids(pm, :transformer)

--- a/test/capacitor.jl
+++ b/test/capacitor.jl
@@ -31,6 +31,21 @@
         @test all(isapprox.(result["solution"]["shunt"]["c1"]["cap_state"], [1.0]; atol=2e-1))
     end
 
+    @testset "capcontrol_ivr" begin
+        result = solve_mc_opf_capc(IEEE13_CapControl, IVRUPowerModel, ipopt_solver; solution_processors=[sol_data_model!])
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+
+        @test isapprox(sum(result["solution"]["voltage_source"]["source"]["pg"]), 405.556; atol=5)
+        @test isapprox(sum(result["solution"]["voltage_source"]["source"]["qg"]), -527.15; atol=300)
+
+        vbase,_ = calc_voltage_bases(IEEE13_CapControl, IEEE13_CapControl["settings"]["vbases_default"])
+        @test all(isapprox.(result["solution"]["bus"]["646"]["vm"] ./ vbase["646"], [1.03533, 1.06987]; atol=2e-2))
+        @test all(isapprox.(result["solution"]["bus"]["646"]["va"], [-90.1768, 148.498]; atol=3e-1))
+
+        @test all(isapprox.(result["solution"]["shunt"]["c1"]["cap_state"], [1.0]; atol=2e-1))
+    end
+
     @testset "capcontrol_fbs" begin
         result = solve_mc_opf_capc(IEEE13_CapControl, FBSUBFPowerModel, ipopt_solver; solution_processors=[sol_data_model!])
 


### PR DESCRIPTION
This PR adds capacitor control to IVR formulation. This control emulates a typical utility wye-connected capacitor by sending switching messages.