### PR TITLE
FIX: bug in _map_eng2math_bus! function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug in `_map_eng2math_bus!()` regarding calculation of shunt element susceptance parameter
 - Added SOC transformer relaxations
 - Fixed bugs in center-tap transformer modeling
 - Add wye-connected CapControl for IVR and FOT (polar) formulations

--- a/src/data_model/eng2math.jl
+++ b/src/data_model/eng2math.jl
@@ -330,7 +330,7 @@ function _map_eng2math_bus!(data_math::Dict{String,<:Any}, data_eng::Dict{String
                 "shunt_bus" => math_obj["bus_i"],
                 "connections" => sh_connections,
                 "gs" => real.(sh_y),
-                "bs" => real.(sh_y),
+                "bs" => imag.(sh_y),
             )
             push!(to_sh, "shunt.$sh_index")
         end


### PR DESCRIPTION
This PR fixes the bug in `_map_eng2math_bus!()` related to shunts where `bs` was calculated using real component of the admittance instead of the imaginary component.