### PR TITLE
FIX: check if bus property is vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug in `get_defined_buses` to check if `"bus"` property is a `Vector` instead of checking if it is a `String` [#416](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/416)
 - Fixed bug in `_map_eng2math_bus!()` regarding calculation of shunt element susceptance parameter
 - Added SOC transformer relaxations
 - Fixed bugs in center-tap transformer modeling

--- a/src/data_model/transformations.jl
+++ b/src/data_model/transformations.jl
@@ -1331,7 +1331,7 @@ function get_defined_buses(data_eng::Dict{String,Any}; comp_types=pmd_eng_asset_
                 buses = [comp["f_bus"], comp["t_bus"]]
             elseif haskey(comp, "bus")
                 # works for a vector of buses and a single bus as a string
-                buses = isa(comp["bus"], String) ? [comp["bus"]] : comp["bus"]
+                buses = isa(comp["bus"], Vector) ? comp["bus"] : [comp["bus"]]
             else
                 buses = []
             end


### PR DESCRIPTION
instead of checking that the bus property is a string

Closes #416 