### PR TITLE
FIX: property assignment in different file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug in dss parser where properties assigned via `assign_property!` would fail if the object they applied to was not created in the same file [#397](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/397)
 - Fixed bug in `get_defined_buses` to check if `"bus"` property is a `Vector` instead of checking if it is a `String` [#416](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/416)
 - Fixed bug in `_map_eng2math_bus!()` regarding calculation of shunt element susceptance parameter
 - Added SOC transformer relaxations

--- a/test/data/opendss/test2_edit.dss
+++ b/test/data/opendss/test2_edit.dss
@@ -1,1 +1,3 @@
 edit transformer.t5 wdg=2 %r=0.76 wdg=1 %r=0.74
+
+storage.s1.bus1 = _b2

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -64,6 +64,10 @@
         @test all(eng["transformer"]["t5"]["rw"] .== [0.0074, 0.0076])
     end
 
+    @testset "dss assign property in different file" begin
+        @test eng["storage"]["s1"]["bus"] == "_b2"
+    end
+
     @testset "subdirectory parsing" begin
         @test haskey(eng["linecode"], "lc7")
     end


### PR DESCRIPTION
Fixes a bug where if a property is assigned via the pattern, e.g.,

`load.a1.bus1 = some_bus`

in a file that is different from the one where `load.a1` was defined, the assignment would fail.

Closes #397