### PR TITLE
ADD: UBF Matrix Power Variables for Switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## staged
 
-- none
+- Added UBF matrix power variables for switches [#423](https://github.com/lanl-ansi/PowerModelsDistribution.jl/issues/423)
 
 ## v0.14.5
 

--- a/test/test_cases.jl
+++ b/test/test_cases.jl
@@ -12,6 +12,7 @@ case3_balanced_pv = parse_file("../test/data/opendss/case3_balanced_pv.dss")
 case3_unbalanced_1phase_pv = parse_file("../test/data/opendss/case3_unbalanced_1phase-pv.dss")
 case3_blanced_basefreq = parse_file("../test/data/opendss/case3_balanced_basefreq.dss")
 case3_balanced_battery = parse_file("../test/data/opendss/case3_balanced_battery.dss")
+case3_balanced_switch = parse_file("../test/data/opendss/case3_balanced_switch.dss")
 
 # 3-bus unbalanced
 case3_unbalanced = parse_file("../test/data/opendss/case3_unbalanced.dss")


### PR DESCRIPTION
This adds matrix P and Q variables for switches to AbstractUBFModels.

Closes #423
Resolves #352 