### PR TITLE
FIX: p&q vars overwritten in IVRU formulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug where `var(pm, :p)` and `var(pm, :q)` in the `IVRUPowerModel` formulation were being overwritten by transformer and switch variable functions
 - Rewrite of dss parser for increased robustness and to avoid edge cases. Instead of parsing raw dss into Dicts, we use vectors of string pairs to preserve the order of commands. This more closely replicates proper dss parsing (**breaking**)
 - Rewrite of `dss2eng` transformation function to support new dss data model (**breaking**)
 - Added new `struct`s and `abstract type`s for data models to support dss parser rewrite, including interfaces so that these new objects can be interacted with similarly to Dicts, to aid in transition to new dss data model

--- a/src/form/ivr.jl
+++ b/src/form/ivr.jl
@@ -69,8 +69,8 @@ function variable_mc_transformer_current(pm::AbstractUnbalancedIVRModel; nw::Int
         q[(l,j,i)] = vi_to.*cr_to  - vr_to.*ci_to
     end
 
-    var(pm, nw)[:p] = p
-    var(pm, nw)[:q] = q
+    var(pm, nw)[:pt] = p
+    var(pm, nw)[:qt] = q
     report && _IM.sol_component_value_edge(pm, pmd_it_sym, nw, :transformer, :pf, :pt, ref(pm, nw, :arcs_transformer_from), ref(pm, nw, :arcs_transformer_to), p)
     report && _IM.sol_component_value_edge(pm, pmd_it_sym, nw, :transformer, :qf, :qt, ref(pm, nw, :arcs_transformer_from), ref(pm, nw, :arcs_transformer_to), q)
 end
@@ -104,8 +104,8 @@ function variable_mc_switch_current(pm::AbstractUnbalancedIVRModel; nw::Int=nw_i
         q[(l,j,i)] = vi_to.*cr_to  - vr_to.*ci_to
     end
 
-    var(pm, nw)[:p] = p
-    var(pm, nw)[:q] = q
+    var(pm, nw)[:psw] = p
+    var(pm, nw)[:qsw] = q
 
     report && _IM.sol_component_value_edge(pm, pmd_it_sym, nw, :switch, :psw_fr, :psw_to, ref(pm, nw, :arcs_switch_from), ref(pm, nw, :arcs_switch_to), p)
     report && _IM.sol_component_value_edge(pm, pmd_it_sym, nw, :switch, :qsw_fr, :qsw_to, ref(pm, nw, :arcs_switch_from), ref(pm, nw, :arcs_switch_to), q)

--- a/test/opf_iv.jl
+++ b/test/opf_iv.jl
@@ -28,5 +28,15 @@
             @test isapprox(sum(result["solution"]["voltage_source"]["source"]["pg"]), 21.4812; atol=1e-2)
             @test isapprox(sum(result["solution"]["voltage_source"]["source"]["qg"]), 9.27263; atol=1e-2)
         end
+
+        @testset "ivr opf power variable expressions" begin
+            math = transform_data_model(IEEE13_Assets)
+
+            pm = instantiate_mc_model(IEEE13_Assets, IVRUPowerModel, build_mc_opf)
+
+            @test length(var(pm, :p)) == length(math["branch"])*2 && length(var(pm, :q)) == length(math["branch"])*2
+            @test length(var(pm, :pt)) == length(math["transformer"])*2 && length(var(pm, :qt)) == length(math["transformer"])*2
+            @test length(var(pm, :psw)) == length(math["switch"])*2 && length(var(pm, :qsw)) == length(math["switch"])*2
+        end
     end
 end

--- a/test/test_cases.jl
+++ b/test/test_cases.jl
@@ -52,6 +52,7 @@ ut_trans_3w_dyy_3_loadloss = parse_file("../test/data/opendss/ut_trans_3w_dyy_3_
 trans_3w_center_tap = parse_file("../test/data/opendss/trans_3w_center_tap.dss")
 
 # IEEE13
+IEEE13_Assets = parse_file("../test/data/opendss/IEEE13_Assets.dss")
 IEEE13_RegControl = parse_file("../test/data/opendss/IEEE13_RegControl.dss"; transformations=[remove_line_limits!, remove_transformer_limits!])
 IEEE13_CapControl = parse_file("../test/data/opendss/IEEE13_CapControl.dss"; transformations=[remove_line_limits!, remove_transformer_limits!])
 


### PR DESCRIPTION
branch p and q variables were being overwritten with transformer and switch variables in the IVRU formulation. This fix ensures that separate pt and qt and psw and qsw variables are created for transformers and switches, respectively.

Closes #437