### PR TITLE
FIX: dss parsing of object names with '.' char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug where `.` chars in dss object names would cause part of the name of the object to get dropped
 - Fixed bug where `var(pm, :p)` and `var(pm, :q)` in the `IVRUPowerModel` formulation were being overwritten by transformer and switch variable functions
 - Rewrite of dss parser for increased robustness and to avoid edge cases. Instead of parsing raw dss into Dicts, we use vectors of string pairs to preserve the order of commands. This more closely replicates proper dss parsing (**breaking**)
 - Rewrite of `dss2eng` transformation function to support new dss data model (**breaking**)

--- a/src/io/dss/parse.jl
+++ b/src/io/dss/parse.jl
@@ -56,7 +56,7 @@ end
 
 ""
 function _parse_dss_obj_type_name(dss_obj_type_name::AbstractString)::Vector{String}
-    obj_type_name = string.(split(replace(replace(dss_obj_type_name, "\""=>""), "\'"=>""), '.'))
+    obj_type_name = string.(split(replace(replace(dss_obj_type_name, "\""=>""), "\'"=>""), '.'; limit=2))
 end
 
 

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -104,3 +104,6 @@ setbusxy bus=testsource x=0.1 y=0.2
 
 new regcontrol.t1  transformer=t1 winding=2  vreg=122  band=2  ptratio=20 ctprim=700  R=3   X=9
 New CapControl.c1_Ctrl Capacitor=c1 element=Line.L2  terminal=1 type=kvar ptratio=1 ctratio=1 ONsetting=150 OFFsetting=-225 VoltOverride=Y Vmin=7110 Vmax=7740 Delay=100 Delayoff=100
+
+new linecode.random_.001-test-name like=L2
+new line.test_.002 like=L2 bus1=_b2 bus2=b10 linecode=random_.001-test-name

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -57,6 +57,11 @@
     eng = parse_file("../test/data/opendss/test2_master.dss", import_all=true)
     math = parse_file("../test/data/opendss/test2_master.dss"; data_model=MATHEMATICAL, import_all=true)
 
+    @testset "dss . characters in name" begin
+        @test haskey(eng["linecode"], "random_.001-test-name")
+        @test eng["line"]["test_.002"]["linecode"] == "random_.001-test-name"
+    end
+
     @testset "dss edit command" begin
         @test all(eng["transformer"]["t5"][k] == v for (k,v) in eng["transformer"]["t4"] if !(k in ["name", "bus", "source_id", "rw", "tm_set", "dss", "controls", "tm_nom"]))
         @test all(eng["transformer"]["t5"]["rw"] .== [0.0074, 0.0076])
@@ -92,7 +97,7 @@
         @test length(math) == 18
         @test length([p for p in propertynames(raw_dss) if !isempty(getproperty(raw_dss, p))]) == 23
 
-        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "transformer", "storage", "switch"], [34, 4, 5, 28, 5, 10, 1, 1])
+        for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "transformer", "storage", "switch"], [34, 4, 5, 29, 5, 10, 1, 1])
             @test haskey(math, key)
             @test length(math[key]) == len
         end


### PR DESCRIPTION
This fixes a bug where dss allows for '.' characters in the name of the object, but we were previously splitting on all '.' chars, causing us to drop part of the name in some cases.

Resolves #441