### PR TITLE
FIX: transformer control dss2eng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Fixed bug where controls for transformer banks with phases not starting with `1` would throw a parsing error due to the wrong conductor identifier `c`
 - Fixed bug where `.` chars in dss object names would cause part of the name of the object to get dropped
 - Fixed bug where `var(pm, :p)` and `var(pm, :q)` in the `IVRUPowerModel` formulation were being overwritten by transformer and switch variable functions
 - Rewrite of dss parser for increased robustness and to avoid edge cases. Instead of parsing raw dss into Dicts, we use vectors of string pairs to preserve the order of commands. This more closely replicates proper dss parsing (**breaking**)

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -250,10 +250,9 @@ function _bank_transformers!(data_eng::Dict{String,<:Any})
                     "x" => [[0.0 for (i,p) in locs] for w in 1:nrw]
                 )
             end
-            for (i,p) in locs
+            for (c,(i,p)) in enumerate(locs)
                 if haskey(trs[i],"controls")
                     for w in 1:nrw
-                        c = f_phases_loc[i][1]
                         btrans["controls"]["vreg"][w][c] = trs[i]["controls"]["vreg"][w][p]
                         btrans["controls"]["band"][w][c] = trs[i]["controls"]["band"][w][p]
                         btrans["controls"]["ptratio"][w][c] = trs[i]["controls"]["ptratio"][w][p]

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -248,6 +248,15 @@
             @test all(isapprox.(result["solution"]["transformer"]["reg1"]["tap"][2], [1.01535, 1.04071, 1.04210]; atol=3e-2))
         end
 
+        @testset "regcontrol parsing" begin
+            dss = parse_dss("../test/data/opendss/IEEE13_test_controls.dss")
+            delete!(dss.transformer, "reg1a")
+
+            eng = parse_opendss(dss)
+            @test eng["transformer"]["reg1"]["controls"]["band"][1][2] == 4.0
+            @test eng["transformer"]["reg1"]["controls"]["band"][2][1] == 3.0
+        end
+
         @testset "3w transformer acp opf center-tap" begin
             result = solve_mc_opf(trans_3w_center_tap, ACPUPowerModel, ipopt_solver; make_si=false)
             @test result["termination_status"] == LOCALLY_SOLVED
@@ -307,7 +316,7 @@
         @testset "3w transformer fotr opf center-tap" begin
             apply_voltage_bounds!(trans_3w_center_tap; vm_lb=0.95, vm_ub=1.05)
             result = solve_mc_opf(trans_3w_center_tap, FOTRUPowerModel, ipopt_solver; solution_processors=[sol_data_model!], make_si=false)
-            @test result["termination_status"] == LOCALLY_SOLVED
+            @test result["termination_status"] == LOCALLY_SOLVED || result["termination_status"] == ALMOST_LOCALLY_SOLVED
 
             sbase = trans_3w_center_tap["settings"]["sbase_default"]
 


### PR DESCRIPTION
There is a bug in _bank_transformers! where if a transformer bank has controls, but either has non-sequential phases, e.g., (1, 3) or has phases not starting with 1, e.g., (2,3), then the function would throw an error because the destination conductor index `c` was wrong.

Also fixes occasionally failing test

Resolves #443