### PR TITLE
[add] solve_mn_mc_opf_oltc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## staged
 
+- Added function `solve_mn_mc_opf_oltc` for multi-networks
 - Fixed bug in `DssLine` parser where `c1` was being set to `c0`
 - Fixed native pf unit tests, which assume no virtual branches from switches (applied `make_lossless!` before test)
 - Added `g_fr`, `g_to`, `b_fr`, `b_to` to switches in `dss2eng` and `eng2math`

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -507,8 +507,10 @@ function variable_mc_oltc_transformer_tap(pm::AbstractUnbalancedPowerModel; nw::
 
     if bounded
         for tr_id in p_oltc_ids, p in 1:length(ref(pm,nw,:transformer,tr_id,"f_connections"))
-            set_lower_bound(var(pm, nw)[:tap][tr_id][p], ref(pm, nw, :transformer, tr_id, "tm_lb")[p])
-            set_upper_bound(var(pm, nw)[:tap][tr_id][p], ref(pm, nw, :transformer, tr_id, "tm_ub")[p])
+            if haskey(ref(pm, nw, :transformer, tr_id), "tm_lb") && haskey(ref(pm, nw, :transformer, tr_id), "tm_ub")
+                set_lower_bound(var(pm, nw)[:tap][tr_id][p], ref(pm, nw, :transformer, tr_id, "tm_lb")[p])
+                set_upper_bound(var(pm, nw)[:tap][tr_id][p], ref(pm, nw, :transformer, tr_id, "tm_ub")[p])
+            end
         end
     end
 

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -4,6 +4,22 @@ function solve_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, model_type::T
 end
 
 
+"""
+	function solve_mn_mc_opf_oltc(
+		data::Union{Dict{String,<:Any},String},
+		model_type::Type,
+		solver;
+		kwargs...
+	)
+
+Solve multinetwork oltc optimal power flow problem
+"""
+function solve_mn_mc_opf_oltc(data::Union{Dict{String,<:Any},String}, model_type::Type, solver; kwargs...)
+    return solve_mc_model(data, model_type, solver, build_mn_mc_opf_oltc; multinetwork=true, kwargs...)
+end
+
+
+
 "constructor for on-load tap-changer OPF"
 function build_mc_opf_oltc(pm::AbstractUnbalancedPowerModel)
     variable_mc_bus_voltage(pm)
@@ -135,5 +151,90 @@ function build_mc_opf_oltc(pm::AbstractUBFModels)
     end
 
     # Objective
+    objective_mc_min_fuel_cost(pm)
+end
+
+
+"""
+	function build_mc_opf_oltc(
+		pm::AbstractUnbalancedPowerModel
+	)
+
+Constructor for otlc Optimal Power Flow
+"""
+function build_mn_mc_opf_oltc(pm::AbstractUnbalancedPowerModel)
+    for (n, network) in nws(pm)
+        variable_mc_bus_voltage(pm; nw=n)
+        variable_mc_branch_power(pm; nw=n)
+        variable_mc_switch_power(pm; nw=n)
+        variable_mc_transformer_power(pm; nw=n)
+        variable_mc_oltc_transformer_tap(pm; nw=n)  
+        variable_mc_generator_power(pm; nw=n)
+        variable_mc_load_power(pm; nw=n)
+        variable_mc_storage_power(pm; nw=n)
+
+        constraint_mc_model_voltage(pm; nw=n)
+
+        for i in ids(pm, n, :ref_buses)
+            constraint_mc_theta_ref(pm, i; nw=n)
+        end
+
+        # generators should be constrained before KCL, or Pd/Qd undefined
+        for id in ids(pm, n,:gen)
+            constraint_mc_generator_power(pm, id; nw=n)
+        end
+
+        # loads should be constrained before KCL, or Pd/Qd undefined
+        for id in ids(pm, n, :load)
+            constraint_mc_load_power(pm, id; nw=n)
+        end
+
+        for i in ids(pm, n, :bus)
+            constraint_mc_power_balance(pm, i; nw=n)
+        end
+
+        for i in ids(pm, n, :storage)
+            constraint_storage_complementarity_nl(pm, i; nw=n)
+            constraint_mc_storage_losses(pm, i; nw=n)
+            constraint_mc_storage_thermal_limit(pm, i; nw=n)
+        end
+
+        for i in ids(pm, n, :branch)
+            constraint_mc_ohms_yt_from(pm, i; nw=n)
+            constraint_mc_ohms_yt_to(pm, i; nw=n)
+            constraint_mc_voltage_angle_difference(pm, i; nw=n)
+            constraint_mc_thermal_limit_from(pm, i; nw=n)
+            constraint_mc_thermal_limit_to(pm, i; nw=n)
+            constraint_mc_ampacity_from(pm, i; nw=n)
+            constraint_mc_ampacity_to(pm, i; nw=n)
+        end
+
+        for i in ids(pm, n, :switch)
+            constraint_mc_switch_state(pm, i; nw=n)
+            constraint_mc_switch_thermal_limit(pm, i; nw=n)
+            constraint_mc_switch_ampacity(pm, i; nw=n)
+        end
+
+        for i in ids(pm, n, :transformer)
+            constraint_mc_transformer_power(pm, i, fix_taps=false; nw=n)
+        end
+    end
+    
+    network_ids = sort(collect(nw_ids(pm)))
+
+    n_1 = network_ids[1]
+
+    for i in ids(pm, :storage; nw=n_1)
+        constraint_storage_state(pm, i; nw=n_1)
+    end
+
+    for n_2 in network_ids[2:end]
+        for i in ids(pm, :storage; nw=n_2)
+            constraint_storage_state(pm, i, n_1, n_2)
+        end
+
+        n_1 = n_2
+    end
+    
     objective_mc_min_fuel_cost(pm)
 end

--- a/src/prob/opf_oltc.jl
+++ b/src/prob/opf_oltc.jl
@@ -156,7 +156,7 @@ end
 
 
 """
-	function build_mc_opf_oltc(
+	function build_mn_mc_opf_oltc(
 		pm::AbstractUnbalancedPowerModel
 	)
 


### PR DESCRIPTION
# Pull Request (PR) Template

Pull requests should be single-issue to the extent possible; by focusing a PR on a single issue/topic, code reviews are more manageable, new features are easier to track, code quality is easier to maintain, and technical debt is easier manage.

Every PR to PowerModelsDistribution should strive to meet the following guidelines.

## Title
[ADD] function `solve_mn_mc_opf_oltc`

## Body
Non-breaking. The purpose is to extend `solve_mc_opf_oltc` to the multi-network setting. 

## Code
There are three changes:

- Add function `solve_mn_mc_opf_oltc` to src/prob/opf_oltc.jl
- Add function `build_mn_mc_opf_oltc` to src/prob/opf_oltc.jl. I modeled it on `build_mn_mc_opf`.
- Alter function `variable_mc_oltc_transformer_tap` in src/core/variable.jl to allow for nonexistent transformer keys `tm_lb` and `tm-ub`. I tested `solve_mn_mc_opf_oltc` using IEEE123 parsed from OpenDSS format. The parse did not set values for `tm_lb` and `tm-ub` for the transformers, and without this change the code throws missing key errors. This might not be the best way to handle the missing key issue, as now the default keyword `bounded=true` in the call to `variable_mc_oltc_transformer_tap` might have less meaning. 
- CHANGELOG.md was altered 
 
No documentation was changed, as the sister function `solve_mn_mc_opf` has no documentation. No unit tests were added, as there are no unit tests for the sister function `solve_mc_opf_oltc`. 