### PR TITLE
FIX: blanced to balanced

### DIFF
--- a/test/pf.jl
+++ b/test/pf.jl
@@ -81,7 +81,7 @@
 
     @testset "3-bus balanced no linecode basefreq defined acp pf" begin
         result1 = solve_mc_pf(case3_balanced, ACPUPowerModel, ipopt_solver)
-        result2 = solve_mc_pf(case3_blanced_basefreq, ACPUPowerModel, ipopt_solver)
+        result2 = solve_mc_pf(case3_balanced_basefreq, ACPUPowerModel, ipopt_solver)
 
         @test all(all(isapprox.(result1["solution"]["bus"]["sourcebus"]["vm"], result2["solution"]["bus"]["sourcebus"]["vm"]; atol=1e-8)) for (i, bus) in result1["solution"]["bus"])
         @test all(all(isapprox.(result1["solution"]["bus"]["sourcebus"]["va"], result2["solution"]["bus"]["sourcebus"]["va"]; atol=1e-8)) for (i, bus) in result1["solution"]["bus"])

--- a/test/test_cases.jl
+++ b/test/test_cases.jl
@@ -10,7 +10,7 @@ case3_balanced_cap = parse_file("../test/data/opendss/case3_balanced_cap.dss")
 case3_balanced_isc = parse_file("../test/data/opendss/case3_balanced_isc.dss")
 case3_balanced_pv = parse_file("../test/data/opendss/case3_balanced_pv.dss")
 case3_unbalanced_1phase_pv = parse_file("../test/data/opendss/case3_unbalanced_1phase-pv.dss")
-case3_blanced_basefreq = parse_file("../test/data/opendss/case3_balanced_basefreq.dss")
+case3_balanced_basefreq = parse_file("../test/data/opendss/case3_balanced_basefreq.dss")
 case3_balanced_battery = parse_file("../test/data/opendss/case3_balanced_battery.dss")
 case3_balanced_switch = parse_file("../test/data/opendss/case3_balanced_switch.dss")
 


### PR DESCRIPTION
## Body
This fixes a minor typo in test_cases.jl and test.pf.jl, where "blanced" should be "balanced". The typo has no negative effect, but is fixed here.


