### PR TITLE
FIX: missing semicolon in add start voltage funcs.

### DIFF
--- a/src/data_model/transformations/initialization.jl
+++ b/src/data_model/transformations/initialization.jl
@@ -260,7 +260,7 @@ add_start_vrvi!(data_math::Dict{String,Any}; kwargs...)
 
 Short-hand for [`add_start_voltage`](@ref add_start_voltage) with rectangular coordinates (coordinates=:rectangular).
 """
-add_start_vrvi!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math, coordinates=:rectangular, kwargs...)
+add_start_vrvi!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math; coordinates=:rectangular, kwargs...)
 
 
 """
@@ -268,4 +268,4 @@ add_start_vmva!(data_math::Dict{String,Any}; kwargs...)
 
 Short-hand for [`add_start_voltage`](@ref add_start_voltage) with polar coordinates (coordinates=:polar).
 """
-add_start_vmva!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math, coordinates=:polar, kwargs...)
+add_start_vmva!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math; coordinates=:polar, kwargs...)

--- a/test/data_model.jl
+++ b/test/data_model.jl
@@ -114,4 +114,16 @@
             @test all(isapprox.(rn["solution"]["bus"][bus_id]["vm"], r["solution"]["bus"][bus_id]["vm"]; atol=1e-4))
         end
     end
+
+    @testset "test initilization add start voltage polar and rectangular" begin
+        data_eng = deepcopy(ut_trans_2w_yy)
+        data_math = transform_data_model(data_eng)
+        data_math_rect = deepcopy(data_math)
+        add_start_vrvi!(data_math_rect; explicit_neutral=false)
+        add_start_vmva!(data_math; explicit_neutral=false)
+        @test haskey(data_math_rect["bus"]["1"], "vr_start")
+        @test haskey(data_math_rect["bus"]["1"], "vi_start")
+        @test haskey(data_math["bus"]["1"], "vm_start")
+        @test haskey(data_math["bus"]["1"], "va_start")
+    end
 end


### PR DESCRIPTION
## Body

- This PR adds the missing semicolons in the functions:

```
add_start_vrvi!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math; coordinates=:rectangular, kwargs...).
add_start_vmva!(data_math::Dict{String,Any}; kwargs...) = add_start_voltage!(data_math; coordinates=:polar, kwargs...)
```

The missing semicolon breaks the initialization when using args such as `explicit_neutral=false`.

- Closes #480 
-  Addresses issue identified in #485


## Code

- Unit tests were added to test that starting voltage values were added correctly.